### PR TITLE
Update struct to not be readonly

### DIFF
--- a/ComponentSettings.cs
+++ b/ComponentSettings.cs
@@ -316,7 +316,7 @@ namespace LiveSplit.AutoSplittingRuntime
             }
         }
 
-        readonly struct FileSelectInfo
+        struct FileSelectInfo
         {
             public FileSelectInfo(string k, string f)
             {


### PR DESCRIPTION
I was getting `Feature 'readonly structs' is not available in C# 7.0. Please use language version 7.2 or greater.` before this change, and the properties of the struct are already readonly.