### PR TITLE
Add `.editorconfig` & apply style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,368 @@
+root = true
+
+# All files
+[*]
+indent_style             = space
+trim_trailing_whitespace = true
+
+# New line preferences
+end_of_line          = crlf
+insert_final_newline = true
+
+# Xml project files
+[*.{csproj,proj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets}]
+indent_size = 2
+
+# Other markup files
+[*.{json,xml,yml}]
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_size              = 2
+trim_trailing_whitespace = false
+
+# C# files
+[*.cs]
+indent_size = 4
+
+
+#### C# Style Rules ####
+[*.cs]
+
+file_header_template = unset
+
+# Uncategorized rules (diagnostics without a property equivalent)
+
+dotnet_diagnostic.IDE0001.severity = suggestion # Simplify name
+dotnet_diagnostic.IDE0002.severity = suggestion # Simplify member access
+dotnet_diagnostic.IDE0004.severity = warning    # Remove unnecessary cast
+dotnet_diagnostic.IDE0005.severity = warning    # Remove unnecessary import
+dotnet_diagnostic.IDE0035.severity = suggestion # Remove unreachable code
+dotnet_diagnostic.IDE0050.severity = warning    # Convert anonymous type to tuple
+dotnet_diagnostic.IDE0051.severity = suggestion # Remove unused private member
+dotnet_diagnostic.IDE0052.severity = suggestion # Remove unread private member
+dotnet_diagnostic.IDE0064.severity = suggestion # Make struct fields writable
+dotnet_diagnostic.IDE0080.severity = warning    # Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0082.severity = warning    # Convert `typeof` to `nameof`
+dotnet_diagnostic.IDE0100.severity = warning    # Remove unnecessary equality operator
+dotnet_diagnostic.IDE0110.severity = suggestion # Remove unnecessary discard
+dotnet_diagnostic.IDE0120.severity = warning    # Simplify LINQ expression
+dotnet_diagnostic.IDE0280.severity = warning    # Use `nameof`
+
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = true
+dotnet_sort_system_directives_first     = true
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event    = false:warning
+dotnet_style_qualification_for_field    = false:warning
+dotnet_style_qualification_for_method   = false:warning
+dotnet_style_qualification_for_property = false:warning
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access             = true:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators      = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators             = never_if_unnecessary:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+
+# Expression-level preferences
+dotnet_style_coalesce_expression                                 = true:suggestion
+dotnet_style_collection_initializer                              = true:warning
+dotnet_style_explicit_tuple_names                                = true:warning
+dotnet_style_null_propagation                                    = true:suggestion
+dotnet_style_object_initializer                                  = true:warning
+dotnet_style_operator_placement_when_wrapping                    = beginning_of_line
+dotnet_style_prefer_auto_properties                              = true:warning
+dotnet_style_prefer_collection_expression                        = true:suggestion
+dotnet_style_prefer_compound_assignment                          = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment       = true:silent
+dotnet_style_prefer_conditional_expression_over_return           = false:silent
+dotnet_style_prefer_foreach_explicit_cast_in_source              = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names         = false:suggestion
+dotnet_style_prefer_inferred_tuple_names                         = false:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_simplified_boolean_expressions               = true:suggestion
+dotnet_style_prefer_simplified_interpolation                     = true:suggestion
+csharp_style_throw_expression                                    = false:warning
+
+# Field preferences
+dotnet_style_readonly_field = true:warning
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = suggestion
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental              = false:warning
+dotnet_style_allow_statement_immediately_after_block_experimental = false:warning
+
+
+#### C# Coding Conventions ####
+
+# readonly preferences
+csharp_style_prefer_readonly_struct        = true:warning
+csharp_style_prefer_readonly_struct_member = true:warning
+
+# var preferences
+csharp_style_var_elsewhere             = false:suggestion
+csharp_style_var_for_built_in_types    = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors       = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors    = false:warning
+csharp_style_expression_bodied_indexers        = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas         = when_on_single_line:suggestion
+csharp_style_expression_bodied_local_functions = false:warning
+csharp_style_expression_bodied_methods         = false:warning
+csharp_style_expression_bodied_operators       = false:warning
+csharp_style_expression_bodied_properties      = when_on_single_line:suggestion
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_prefer_not_pattern                       = true:warning
+csharp_style_prefer_extended_property_pattern         = true:warning
+csharp_style_prefer_pattern_matching                  = true:suggestion
+csharp_style_prefer_switch_expression                 = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:warning
+csharp_preferred_modifier_order     = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+
+# Code-block preferences
+csharp_prefer_braces                        = true:warning
+csharp_prefer_simple_using_statement        = true:warning
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_top_level_statements    = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression                     = true:warning
+csharp_style_deconstructed_variable_declaration             = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+csharp_style_inlined_variable_declaration                   = true:warning
+csharp_style_pattern_local_over_anonymous_function          = true:warning
+csharp_style_prefer_index_operator                          = true:warning
+csharp_style_prefer_local_over_anonymous_function           = true:warning
+csharp_style_prefer_null_check_over_type_check              = true:warning
+csharp_style_prefer_range_operator                          = true:warning
+csharp_style_prefer_tuple_swap                              = true:warning
+csharp_style_prefer_utf8_string_literals                    = true:suggestion
+csharp_style_unused_value_assignment_preference             = discard_variable:none
+csharp_style_unused_value_expression_statement_preference   = discard_variable:none
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:warning
+
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch                                                      = true
+csharp_new_line_before_else                                                       = true
+csharp_new_line_before_finally                                                    = true
+csharp_new_line_before_members_in_anonymous_types                                 = true
+csharp_new_line_before_members_in_object_initializers                             = true
+csharp_new_line_before_open_brace                                                 = all
+csharp_new_line_between_query_expression_clauses                                  = true
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false:warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental  = false:warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false:warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental            = false:warning
+csharp_style_allow_embedded_statements_on_same_line_experimental                  = false:warning
+
+# Indentation preferences
+csharp_indent_block_contents           = true
+csharp_indent_braces                   = false
+csharp_indent_case_contents            = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels                   = one_less_than_current
+csharp_indent_switch_labels            = true
+
+# Space preferences
+csharp_space_after_cast                                                  = false
+csharp_space_after_colon_in_inheritance_clause                           = true
+csharp_space_after_comma                                                 = true
+csharp_space_after_dot                                                   = false
+csharp_space_after_keywords_in_control_flow_statements                   = true
+csharp_space_after_semicolon_in_for_statement                            = true
+csharp_space_around_binary_operators                                     = before_and_after
+csharp_space_around_declaration_statements                               = false
+csharp_space_before_colon_in_inheritance_clause                          = true
+csharp_space_before_comma                                                = false
+csharp_space_before_dot                                                  = false
+csharp_space_before_open_square_brackets                                 = false
+csharp_space_before_semicolon_in_for_statement                           = false
+csharp_space_between_empty_square_brackets                               = false
+csharp_space_between_method_call_empty_parameter_list_parentheses        = false
+csharp_space_between_method_call_name_and_opening_parenthesis            = false
+csharp_space_between_method_call_parameter_list_parentheses              = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis        = false
+csharp_space_between_method_declaration_parameter_list_parentheses       = false
+csharp_space_between_parentheses                                         = false
+csharp_space_between_square_brackets                                     = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks     = true
+csharp_preserve_single_line_statements = true
+
+# Namespace preferences
+csharp_style_namespace_declarations = file_scoped:warning
+dotnet_style_namespace_match_folder = false
+
+# Constructor preferences
+csharp_style_prefer_primary_constructors = false:none
+
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.symbols  = types_and_namespaces
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.interfaces_should_be_ipascalcase.severity = suggestion
+dotnet_naming_rule.interfaces_should_be_ipascalcase.symbols  = interfaces
+dotnet_naming_rule.interfaces_should_be_ipascalcase.style    = ipascalcase
+
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols  = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.constant_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascalcase.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.symbols  = public_static_fields
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_fields_should_be_pascalcase.symbols  = public_fields
+dotnet_naming_rule.public_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.private_fields_should_be__camelcase.severity = suggestion
+dotnet_naming_rule.private_fields_should_be__camelcase.symbols  = private_fields
+dotnet_naming_rule.private_fields_should_be__camelcase.style    = _camelcase
+
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.symbols  = type_parameters
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.style    = tpascalcase
+
+dotnet_naming_rule.parameters_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.parameters_should_be_camelcase.symbols  = parameters
+dotnet_naming_rule.parameters_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_constants_should_be_pascalcase.severity = warning
+dotnet_naming_rule.local_constants_should_be_pascalcase.symbols  = local_constants
+dotnet_naming_rule.local_constants_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.local_variables_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variables_should_be_camelcase.symbols  = local_variables
+dotnet_naming_rule.local_variables_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_functions_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_functions_should_be_camelcase.symbols  = local_functions
+dotnet_naming_rule.local_functions_should_be_camelcase.style    = camelcase
+
+# Symbol specifications
+
+dotnet_naming_symbols.types_and_namespaces.applicable_kinds           = namespace, class, struct, interface, enum
+dotnet_naming_symbols.types_and_namespaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types_and_namespaces.required_modifiers         =
+
+dotnet_naming_symbols.interfaces.applicable_kinds           = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interfaces.required_modifiers         =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds           = property, event, delegate, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers         =
+
+dotnet_naming_symbols.constant_fields.applicable_kinds           = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.constant_fields.required_modifiers         = const
+
+dotnet_naming_symbols.public_static_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_static_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_static_fields.required_modifiers         = static
+
+dotnet_naming_symbols.public_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_fields.required_modifiers         =
+
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_fields.required_modifiers         =
+
+dotnet_naming_symbols.type_parameters.applicable_kinds           = type_parameter
+dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameters.required_modifiers         =
+
+dotnet_naming_symbols.parameters.applicable_kinds           = parameter
+dotnet_naming_symbols.parameters.applicable_accessibilities = *
+dotnet_naming_symbols.parameters.required_modifiers         =
+
+dotnet_naming_symbols.local_constants.applicable_kinds           = local
+dotnet_naming_symbols.local_constants.applicable_accessibilities = local
+dotnet_naming_symbols.local_constants.required_modifiers         = const
+
+dotnet_naming_symbols.local_variables.applicable_kinds           = local
+dotnet_naming_symbols.local_variables.applicable_accessibilities = local
+dotnet_naming_symbols.local_variables.required_modifiers         =
+
+dotnet_naming_symbols.local_functions.applicable_kinds           = local_function
+dotnet_naming_symbols.local_functions.applicable_accessibilities = local
+dotnet_naming_symbols.local_functions.required_modifiers         =
+
+# Naming styles
+
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator  =
+dotnet_naming_style.pascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator  =
+dotnet_naming_style.ipascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator  =
+dotnet_naming_style.tpascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator  =
+dotnet_naming_style.camelcase.capitalization  = camel_case
+
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator  =
+dotnet_naming_style._camelcase.capitalization  = camel_case
+
+
+#### Suppressions ####

--- a/props/LiveSplit.AutoSplittingRuntime.props
+++ b/props/LiveSplit.AutoSplittingRuntime.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <LangVersion>12</LangVersion>
 
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/props/LiveSplit.AutoSplittingRuntime.props
+++ b/props/LiveSplit.AutoSplittingRuntime.props
@@ -2,6 +2,8 @@
 
   <!-- Project properties. -->
   <PropertyGroup>
+    <LangVersion>12</LangVersion>
+
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/src/LiveSplit.AutoSplittingRuntime/ASR.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASR.cs
@@ -376,16 +376,16 @@ public class SettingValueRef
         }
 
         UIntPtr ty = ASRNative.SettingValue_get_type(ptr);
-        switch ((ulong)ty)
+        return (ulong)ty switch
         {
-            case 1: return "map";
-            case 2: return "list";
-            case 3: return "bool";
-            case 4: return "i64";
-            case 5: return "f64";
-            case 6: return "string";
-            default: return "";
-        }
+            1 => "map",
+            2 => "list",
+            3 => "bool",
+            4 => "i64",
+            5 => "f64",
+            6 => "string",
+            _ => "",
+        };
     }
     public SettingsMapRef GetMap()
     {
@@ -598,14 +598,14 @@ public class WidgetsRef
         }
 
         UIntPtr ty = ASRNative.Widgets_get_type(ptr, (UIntPtr)index);
-        switch ((ulong)ty)
+        return (ulong)ty switch
         {
-            case 1: return "bool";
-            case 2: return "title";
-            case 3: return "choice";
-            case 4: return "file-select";
-            default: return "";
-        }
+            1 => "bool",
+            2 => "title",
+            3 => "choice",
+            4 => "file-select",
+            _ => "",
+        };
     }
 
     public bool GetBool(ulong index, SettingsMapRef settingsMap)

--- a/src/LiveSplit.AutoSplittingRuntime/ASR.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASR.cs
@@ -797,10 +797,7 @@ public class ASRString : SafeHandle
 
     public ASRString() : base(IntPtr.Zero, false) { }
 
-    public override bool IsInvalid
-    {
-        get { return false; }
-    }
+    public override bool IsInvalid => false;
 
     public static implicit operator ASRString(string managedString)
     {

--- a/src/LiveSplit.AutoSplittingRuntime/ASR.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASR.cs
@@ -861,7 +861,7 @@ public class ASRString : SafeHandle
 
     public static string FromPtrLen(IntPtr ptr, UIntPtr len)
     {
-        if (ptr == IntPtr.Zero || (ulong)len > (ulong)int.MaxValue)
+        if (ptr == IntPtr.Zero || (ulong)len > int.MaxValue)
         {
             return null;
         }

--- a/src/LiveSplit.AutoSplittingRuntime/ASR.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASR.cs
@@ -26,7 +26,7 @@ public class Runtime : RuntimeRefMut, IDisposable
     {
         if (ptr != IntPtr.Zero)
         {
-            ASRNative.Runtime_drop(this.ptr);
+            ASRNative.Runtime_drop(ptr);
             ptr = IntPtr.Zero;
         }
     }
@@ -60,7 +60,7 @@ public class Runtime : RuntimeRefMut, IDisposable
             settingsMap.ptr = IntPtr.Zero;
         }
 
-        this.ptr = ASRNative.Runtime_new(
+        ptr = ASRNative.Runtime_new(
             path,
             settingsMapPtr,
             state,
@@ -74,7 +74,7 @@ public class Runtime : RuntimeRefMut, IDisposable
             resumeGameTime,
             log
         );
-        if (this.ptr == IntPtr.Zero)
+        if (ptr == IntPtr.Zero)
         {
             throw new ArgumentException("Couldn't load the module provided.");
         }
@@ -88,7 +88,7 @@ public class Runtime : RuntimeRefMut, IDisposable
             return false;
         }
 
-        return ASRNative.Runtime_step(this.ptr);
+        return ASRNative.Runtime_step(ptr);
     }
 
     public TimeSpan TickRate()
@@ -98,7 +98,7 @@ public class Runtime : RuntimeRefMut, IDisposable
             return TimeSpan.Zero;
         }
 
-        return new TimeSpan((long)ASRNative.Runtime_tick_rate(this.ptr));
+        return new TimeSpan((long)ASRNative.Runtime_tick_rate(ptr));
     }
 
     public Widgets GetSettingsWidgets()
@@ -108,7 +108,7 @@ public class Runtime : RuntimeRefMut, IDisposable
             return null;
         }
 
-        return new Widgets(ASRNative.Runtime_get_settings_widgets(this.ptr));
+        return new Widgets(ASRNative.Runtime_get_settings_widgets(ptr));
     }
 
     public void SettingsMapSetBool(string key, bool value)
@@ -118,7 +118,7 @@ public class Runtime : RuntimeRefMut, IDisposable
             return;
         }
 
-        ASRNative.Runtime_settings_map_set_bool(this.ptr, key, value ? (byte)1 : (byte)0);
+        ASRNative.Runtime_settings_map_set_bool(ptr, key, value ? (byte)1 : (byte)0);
     }
 
     public void SettingsMapSetString(string key, string value)
@@ -128,7 +128,7 @@ public class Runtime : RuntimeRefMut, IDisposable
             return;
         }
 
-        ASRNative.Runtime_settings_map_set_string(this.ptr, key, value);
+        ASRNative.Runtime_settings_map_set_string(ptr, key, value);
     }
 
     public SettingsMap GetSettingsMap()
@@ -138,7 +138,7 @@ public class Runtime : RuntimeRefMut, IDisposable
             return null;
         }
 
-        return new SettingsMap(ASRNative.Runtime_get_settings_map(this.ptr));
+        return new SettingsMap(ASRNative.Runtime_get_settings_map(ptr));
     }
 
     public void SetSettingsMap(SettingsMap settingsMap)
@@ -155,7 +155,7 @@ public class Runtime : RuntimeRefMut, IDisposable
         }
 
         settingsMap.ptr = IntPtr.Zero;
-        ASRNative.Runtime_set_settings_map(this.ptr, settingsMapPtr);
+        ASRNative.Runtime_set_settings_map(ptr, settingsMapPtr);
     }
 
     public bool AreSettingsChanged(SettingsMapRef previousSettingsMap, WidgetsRef previousWidgets)
@@ -175,7 +175,7 @@ public class Runtime : RuntimeRefMut, IDisposable
             return false;
         }
 
-        return ASRNative.Runtime_are_settings_changed(this.ptr, previousSettingsMap.ptr, previousWidgets.ptr) != 0;
+        return ASRNative.Runtime_are_settings_changed(ptr, previousSettingsMap.ptr, previousWidgets.ptr) != 0;
     }
 }
 
@@ -193,7 +193,7 @@ public class SettingsMapRef
             return 0;
         }
 
-        return (ulong)ASRNative.SettingsMap_len(this.ptr);
+        return (ulong)ASRNative.SettingsMap_len(ptr);
     }
     public string GetKey(ulong index)
     {
@@ -202,7 +202,7 @@ public class SettingsMapRef
             return "";
         }
 
-        return ASRNative.SettingsMap_get_key(this.ptr, (UIntPtr)index);
+        return ASRNative.SettingsMap_get_key(ptr, (UIntPtr)index);
     }
     public SettingValueRef GetValue(ulong index)
     {
@@ -211,7 +211,7 @@ public class SettingsMapRef
             return null;
         }
 
-        return new SettingValueRef(ASRNative.SettingsMap_get_value(this.ptr, (UIntPtr)index));
+        return new SettingValueRef(ASRNative.SettingsMap_get_value(ptr, (UIntPtr)index));
     }
     public SettingValueRef KeyGetValue(string key)
     {
@@ -220,7 +220,7 @@ public class SettingsMapRef
             return null;
         }
 
-        var valuePtr = ASRNative.SettingsMap_get_value_by_key(this.ptr, key);
+        var valuePtr = ASRNative.SettingsMap_get_value_by_key(ptr, key);
         if (valuePtr != IntPtr.Zero)
         {
             return new SettingValueRef(valuePtr);
@@ -249,7 +249,7 @@ public class SettingsMapRefMut : SettingsMapRef
         }
 
         value.ptr = IntPtr.Zero;
-        ASRNative.SettingsMap_insert(this.ptr, key, valuePtr);
+        ASRNative.SettingsMap_insert(ptr, key, valuePtr);
     }
 }
 
@@ -259,7 +259,7 @@ public class SettingsMap : SettingsMapRefMut, IDisposable
     {
         if (ptr != IntPtr.Zero)
         {
-            ASRNative.SettingsMap_drop(this.ptr);
+            ASRNative.SettingsMap_drop(ptr);
             ptr = IntPtr.Zero;
         }
     }
@@ -274,8 +274,8 @@ public class SettingsMap : SettingsMapRefMut, IDisposable
     }
     public SettingsMap() : base(IntPtr.Zero)
     {
-        this.ptr = ASRNative.SettingsMap_new();
-        if (this.ptr == IntPtr.Zero)
+        ptr = ASRNative.SettingsMap_new();
+        if (ptr == IntPtr.Zero)
         {
             throw new ArgumentException("Couldn't create the settings map.");
         }
@@ -297,7 +297,7 @@ public class SettingsListRef
             return 0;
         }
 
-        return (ulong)ASRNative.SettingsList_len(this.ptr);
+        return (ulong)ASRNative.SettingsList_len(ptr);
     }
     public SettingValueRef Get(ulong index)
     {
@@ -306,7 +306,7 @@ public class SettingsListRef
             return null;
         }
 
-        return new SettingValueRef(ASRNative.SettingsList_get(this.ptr, (UIntPtr)index));
+        return new SettingValueRef(ASRNative.SettingsList_get(ptr, (UIntPtr)index));
     }
 }
 
@@ -327,7 +327,7 @@ public class SettingsListRefMut : SettingsListRef
         }
 
         value.ptr = IntPtr.Zero;
-        ASRNative.SettingsList_push(this.ptr, valuePtr);
+        ASRNative.SettingsList_push(ptr, valuePtr);
     }
 }
 
@@ -337,7 +337,7 @@ public class SettingsList : SettingsListRefMut, IDisposable
     {
         if (ptr != IntPtr.Zero)
         {
-            ASRNative.SettingsList_drop(this.ptr);
+            ASRNative.SettingsList_drop(ptr);
             ptr = IntPtr.Zero;
         }
     }
@@ -352,8 +352,8 @@ public class SettingsList : SettingsListRefMut, IDisposable
     }
     public SettingsList() : base(IntPtr.Zero)
     {
-        this.ptr = ASRNative.SettingsList_new();
-        if (this.ptr == IntPtr.Zero)
+        ptr = ASRNative.SettingsList_new();
+        if (ptr == IntPtr.Zero)
         {
             throw new ArgumentException("Couldn't create the settings list.");
         }
@@ -375,7 +375,7 @@ public class SettingValueRef
             return "";
         }
 
-        var ty = ASRNative.SettingValue_get_type(this.ptr);
+        var ty = ASRNative.SettingValue_get_type(ptr);
         switch ((ulong)ty)
         {
             case 1: return "map";
@@ -394,7 +394,7 @@ public class SettingValueRef
             return null;
         }
 
-        return new SettingsMapRef(ASRNative.SettingValue_get_map(this.ptr));
+        return new SettingsMapRef(ASRNative.SettingValue_get_map(ptr));
     }
     public SettingsListRef GetList()
     {
@@ -403,7 +403,7 @@ public class SettingValueRef
             return null;
         }
 
-        return new SettingsListRef(ASRNative.SettingValue_get_list(this.ptr));
+        return new SettingsListRef(ASRNative.SettingValue_get_list(ptr));
     }
     public bool GetBool()
     {
@@ -412,7 +412,7 @@ public class SettingValueRef
             return false;
         }
 
-        return ASRNative.SettingValue_get_bool(this.ptr) != 0;
+        return ASRNative.SettingValue_get_bool(ptr) != 0;
     }
     public long GetI64()
     {
@@ -421,7 +421,7 @@ public class SettingValueRef
             return 0;
         }
 
-        return ASRNative.SettingValue_get_i64(this.ptr);
+        return ASRNative.SettingValue_get_i64(ptr);
     }
     public double GetF64()
     {
@@ -430,7 +430,7 @@ public class SettingValueRef
             return 0;
         }
 
-        return ASRNative.SettingValue_get_f64(this.ptr);
+        return ASRNative.SettingValue_get_f64(ptr);
     }
     public string GetString()
     {
@@ -439,7 +439,7 @@ public class SettingValueRef
             return "";
         }
 
-        return ASRNative.SettingValue_get_string(this.ptr);
+        return ASRNative.SettingValue_get_string(ptr);
     }
 }
 
@@ -454,7 +454,7 @@ public class SettingValue : SettingValueRefMut, IDisposable
     {
         if (ptr != IntPtr.Zero)
         {
-            ASRNative.SettingValue_drop(this.ptr);
+            ASRNative.SettingValue_drop(ptr);
             ptr = IntPtr.Zero;
         }
     }
@@ -469,32 +469,32 @@ public class SettingValue : SettingValueRefMut, IDisposable
     }
     public SettingValue(bool value) : base(IntPtr.Zero)
     {
-        this.ptr = ASRNative.SettingValue_new_bool(value ? (byte)1 : (byte)0);
-        if (this.ptr == IntPtr.Zero)
+        ptr = ASRNative.SettingValue_new_bool(value ? (byte)1 : (byte)0);
+        if (ptr == IntPtr.Zero)
         {
             throw new ArgumentException("Couldn't create the setting value.");
         }
     }
     public SettingValue(long value) : base(IntPtr.Zero)
     {
-        this.ptr = ASRNative.SettingValue_new_i64(value);
-        if (this.ptr == IntPtr.Zero)
+        ptr = ASRNative.SettingValue_new_i64(value);
+        if (ptr == IntPtr.Zero)
         {
             throw new ArgumentException("Couldn't create the setting value.");
         }
     }
     public SettingValue(double value) : base(IntPtr.Zero)
     {
-        this.ptr = ASRNative.SettingValue_new_f64(value);
-        if (this.ptr == IntPtr.Zero)
+        ptr = ASRNative.SettingValue_new_f64(value);
+        if (ptr == IntPtr.Zero)
         {
             throw new ArgumentException("Couldn't create the setting value.");
         }
     }
     public SettingValue(string value) : base(IntPtr.Zero)
     {
-        this.ptr = ASRNative.SettingValue_new_string(value);
-        if (this.ptr == IntPtr.Zero)
+        ptr = ASRNative.SettingValue_new_string(value);
+        if (ptr == IntPtr.Zero)
         {
             throw new ArgumentException("Couldn't create the setting value.");
         }
@@ -508,8 +508,8 @@ public class SettingValue : SettingValueRefMut, IDisposable
         }
 
         value.ptr = IntPtr.Zero;
-        this.ptr = ASRNative.SettingValue_new_map(valuePtr);
-        if (this.ptr == IntPtr.Zero)
+        ptr = ASRNative.SettingValue_new_map(valuePtr);
+        if (ptr == IntPtr.Zero)
         {
             throw new ArgumentException("Couldn't create the setting value.");
         }
@@ -523,8 +523,8 @@ public class SettingValue : SettingValueRefMut, IDisposable
         }
 
         value.ptr = IntPtr.Zero;
-        this.ptr = ASRNative.SettingValue_new_list(valuePtr);
-        if (this.ptr == IntPtr.Zero)
+        ptr = ASRNative.SettingValue_new_list(valuePtr);
+        if (ptr == IntPtr.Zero)
         {
             throw new ArgumentException("Couldn't create the setting value.");
         }
@@ -547,7 +547,7 @@ public class WidgetsRef
             return 0;
         }
 
-        return (ulong)ASRNative.Widgets_len(this.ptr);
+        return (ulong)ASRNative.Widgets_len(ptr);
     }
 
     public string GetKey(ulong index)
@@ -557,7 +557,7 @@ public class WidgetsRef
             return "";
         }
 
-        return ASRNative.Widgets_get_key(this.ptr, (UIntPtr)index);
+        return ASRNative.Widgets_get_key(ptr, (UIntPtr)index);
     }
 
     public string GetDescription(ulong index)
@@ -567,7 +567,7 @@ public class WidgetsRef
             return "";
         }
 
-        return ASRNative.Widgets_get_description(this.ptr, (UIntPtr)index);
+        return ASRNative.Widgets_get_description(ptr, (UIntPtr)index);
     }
 
     public string GetTooltip(ulong index)
@@ -577,7 +577,7 @@ public class WidgetsRef
             return "";
         }
 
-        return ASRNative.Widgets_get_tooltip(this.ptr, (UIntPtr)index);
+        return ASRNative.Widgets_get_tooltip(ptr, (UIntPtr)index);
     }
 
     public uint GetHeadingLevel(ulong index)
@@ -587,7 +587,7 @@ public class WidgetsRef
             return 0;
         }
 
-        return ASRNative.Widgets_get_heading_level(this.ptr, (UIntPtr)index);
+        return ASRNative.Widgets_get_heading_level(ptr, (UIntPtr)index);
     }
 
     public string GetType(ulong index)
@@ -597,7 +597,7 @@ public class WidgetsRef
             return "";
         }
 
-        var ty = ASRNative.Widgets_get_type(this.ptr, (UIntPtr)index);
+        var ty = ASRNative.Widgets_get_type(ptr, (UIntPtr)index);
         switch ((ulong)ty)
         {
             case 1: return "bool";
@@ -620,7 +620,7 @@ public class WidgetsRef
             return false;
         }
 
-        return ASRNative.Widgets_get_bool(this.ptr, (UIntPtr)index, settingsMap.ptr) != 0;
+        return ASRNative.Widgets_get_bool(ptr, (UIntPtr)index, settingsMap.ptr) != 0;
     }
 
     public ulong GetChoiceCurrentIndex(ulong index, SettingsMapRef settingsMap)
@@ -635,7 +635,7 @@ public class WidgetsRef
             return 0;
         }
 
-        return (ulong)ASRNative.Widgets_get_choice_current_index(this.ptr, (UIntPtr)index, settingsMap.ptr);
+        return (ulong)ASRNative.Widgets_get_choice_current_index(ptr, (UIntPtr)index, settingsMap.ptr);
     }
 
     public ulong GetChoiceOptionsLength(ulong index)
@@ -645,7 +645,7 @@ public class WidgetsRef
             return 0;
         }
 
-        return (ulong)ASRNative.Widgets_get_choice_options_len(this.ptr, (UIntPtr)index);
+        return (ulong)ASRNative.Widgets_get_choice_options_len(ptr, (UIntPtr)index);
     }
 
     public string GetChoiceOptionKey(ulong index, ulong optionIndex)
@@ -655,7 +655,7 @@ public class WidgetsRef
             return "";
         }
 
-        return ASRNative.Widgets_get_choice_option_key(this.ptr, (UIntPtr)index, (UIntPtr)optionIndex);
+        return ASRNative.Widgets_get_choice_option_key(ptr, (UIntPtr)index, (UIntPtr)optionIndex);
     }
 
     public string GetChoiceOptionDescription(ulong index, ulong optionIndex)
@@ -665,7 +665,7 @@ public class WidgetsRef
             return "";
         }
 
-        return ASRNative.Widgets_get_choice_option_description(this.ptr, (UIntPtr)index, (UIntPtr)optionIndex);
+        return ASRNative.Widgets_get_choice_option_description(ptr, (UIntPtr)index, (UIntPtr)optionIndex);
     }
 
     public string GetFileSelectFilter(ulong index)
@@ -675,7 +675,7 @@ public class WidgetsRef
             return "";
         }
 
-        return ASRNative.Widgets_get_file_select_filter(this.ptr, (UIntPtr)index);
+        return ASRNative.Widgets_get_file_select_filter(ptr, (UIntPtr)index);
     }
 }
 
@@ -690,7 +690,7 @@ public class Widgets : WidgetsRefMut, IDisposable
     {
         if (ptr != IntPtr.Zero)
         {
-            ASRNative.Widgets_drop(this.ptr);
+            ASRNative.Widgets_drop(ptr);
             ptr = IntPtr.Zero;
         }
     }

--- a/src/LiveSplit.AutoSplittingRuntime/ASR.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASR.cs
@@ -59,6 +59,7 @@ public class Runtime : RuntimeRefMut, IDisposable
         {
             settingsMap.ptr = IntPtr.Zero;
         }
+
         this.ptr = ASRNative.Runtime_new(
             path,
             settingsMapPtr,
@@ -86,6 +87,7 @@ public class Runtime : RuntimeRefMut, IDisposable
         {
             return false;
         }
+
         return ASRNative.Runtime_step(this.ptr);
     }
 
@@ -95,6 +97,7 @@ public class Runtime : RuntimeRefMut, IDisposable
         {
             return TimeSpan.Zero;
         }
+
         return new TimeSpan((long)ASRNative.Runtime_tick_rate(this.ptr));
     }
 
@@ -104,6 +107,7 @@ public class Runtime : RuntimeRefMut, IDisposable
         {
             return null;
         }
+
         return new Widgets(ASRNative.Runtime_get_settings_widgets(this.ptr));
     }
 
@@ -113,6 +117,7 @@ public class Runtime : RuntimeRefMut, IDisposable
         {
             return;
         }
+
         ASRNative.Runtime_settings_map_set_bool(this.ptr, key, value ? (byte)1 : (byte)0);
     }
 
@@ -122,6 +127,7 @@ public class Runtime : RuntimeRefMut, IDisposable
         {
             return;
         }
+
         ASRNative.Runtime_settings_map_set_string(this.ptr, key, value);
     }
 
@@ -131,6 +137,7 @@ public class Runtime : RuntimeRefMut, IDisposable
         {
             return null;
         }
+
         return new SettingsMap(ASRNative.Runtime_get_settings_map(this.ptr));
     }
 
@@ -140,11 +147,13 @@ public class Runtime : RuntimeRefMut, IDisposable
         {
             return;
         }
+
         var settingsMapPtr = settingsMap.ptr;
         if (settingsMapPtr == IntPtr.Zero)
         {
             return;
         }
+
         settingsMap.ptr = IntPtr.Zero;
         ASRNative.Runtime_set_settings_map(this.ptr, settingsMapPtr);
     }
@@ -155,14 +164,17 @@ public class Runtime : RuntimeRefMut, IDisposable
         {
             return false;
         }
+
         if (previousSettingsMap.ptr == IntPtr.Zero)
         {
             return false;
         }
+
         if (previousWidgets.ptr == IntPtr.Zero)
         {
             return false;
         }
+
         return ASRNative.Runtime_are_settings_changed(this.ptr, previousSettingsMap.ptr, previousWidgets.ptr) != 0;
     }
 }
@@ -180,6 +192,7 @@ public class SettingsMapRef
         {
             return 0;
         }
+
         return (ulong)ASRNative.SettingsMap_len(this.ptr);
     }
     public string GetKey(ulong index)
@@ -188,6 +201,7 @@ public class SettingsMapRef
         {
             return "";
         }
+
         return ASRNative.SettingsMap_get_key(this.ptr, (UIntPtr)index);
     }
     public SettingValueRef GetValue(ulong index)
@@ -196,6 +210,7 @@ public class SettingsMapRef
         {
             return null;
         }
+
         return new SettingValueRef(ASRNative.SettingsMap_get_value(this.ptr, (UIntPtr)index));
     }
     public SettingValueRef KeyGetValue(string key)
@@ -204,6 +219,7 @@ public class SettingsMapRef
         {
             return null;
         }
+
         var valuePtr = ASRNative.SettingsMap_get_value_by_key(this.ptr, key);
         if (valuePtr != IntPtr.Zero)
         {
@@ -225,11 +241,13 @@ public class SettingsMapRefMut : SettingsMapRef
         {
             return;
         }
+
         var valuePtr = value.ptr;
         if (valuePtr == IntPtr.Zero)
         {
             return;
         }
+
         value.ptr = IntPtr.Zero;
         ASRNative.SettingsMap_insert(this.ptr, key, valuePtr);
     }
@@ -278,6 +296,7 @@ public class SettingsListRef
         {
             return 0;
         }
+
         return (ulong)ASRNative.SettingsList_len(this.ptr);
     }
     public SettingValueRef Get(ulong index)
@@ -286,6 +305,7 @@ public class SettingsListRef
         {
             return null;
         }
+
         return new SettingValueRef(ASRNative.SettingsList_get(this.ptr, (UIntPtr)index));
     }
 }
@@ -299,11 +319,13 @@ public class SettingsListRefMut : SettingsListRef
         {
             return;
         }
+
         var valuePtr = value.ptr;
         if (valuePtr == IntPtr.Zero)
         {
             return;
         }
+
         value.ptr = IntPtr.Zero;
         ASRNative.SettingsList_push(this.ptr, valuePtr);
     }
@@ -352,6 +374,7 @@ public class SettingValueRef
         {
             return "";
         }
+
         var ty = ASRNative.SettingValue_get_type(this.ptr);
         switch ((ulong)ty)
         {
@@ -370,6 +393,7 @@ public class SettingValueRef
         {
             return null;
         }
+
         return new SettingsMapRef(ASRNative.SettingValue_get_map(this.ptr));
     }
     public SettingsListRef GetList()
@@ -378,6 +402,7 @@ public class SettingValueRef
         {
             return null;
         }
+
         return new SettingsListRef(ASRNative.SettingValue_get_list(this.ptr));
     }
     public bool GetBool()
@@ -386,6 +411,7 @@ public class SettingValueRef
         {
             return false;
         }
+
         return ASRNative.SettingValue_get_bool(this.ptr) != 0;
     }
     public long GetI64()
@@ -394,6 +420,7 @@ public class SettingValueRef
         {
             return 0;
         }
+
         return ASRNative.SettingValue_get_i64(this.ptr);
     }
     public double GetF64()
@@ -402,6 +429,7 @@ public class SettingValueRef
         {
             return 0;
         }
+
         return ASRNative.SettingValue_get_f64(this.ptr);
     }
     public string GetString()
@@ -410,6 +438,7 @@ public class SettingValueRef
         {
             return "";
         }
+
         return ASRNative.SettingValue_get_string(this.ptr);
     }
 }
@@ -477,6 +506,7 @@ public class SettingValue : SettingValueRefMut, IDisposable
         {
             throw new ArgumentException("Couldn't create the setting value.");
         }
+
         value.ptr = IntPtr.Zero;
         this.ptr = ASRNative.SettingValue_new_map(valuePtr);
         if (this.ptr == IntPtr.Zero)
@@ -491,6 +521,7 @@ public class SettingValue : SettingValueRefMut, IDisposable
         {
             throw new ArgumentException("Couldn't create the setting value.");
         }
+
         value.ptr = IntPtr.Zero;
         this.ptr = ASRNative.SettingValue_new_list(valuePtr);
         if (this.ptr == IntPtr.Zero)
@@ -515,6 +546,7 @@ public class WidgetsRef
         {
             return 0;
         }
+
         return (ulong)ASRNative.Widgets_len(this.ptr);
     }
 
@@ -524,6 +556,7 @@ public class WidgetsRef
         {
             return "";
         }
+
         return ASRNative.Widgets_get_key(this.ptr, (UIntPtr)index);
     }
 
@@ -533,6 +566,7 @@ public class WidgetsRef
         {
             return "";
         }
+
         return ASRNative.Widgets_get_description(this.ptr, (UIntPtr)index);
     }
 
@@ -542,6 +576,7 @@ public class WidgetsRef
         {
             return "";
         }
+
         return ASRNative.Widgets_get_tooltip(this.ptr, (UIntPtr)index);
     }
 
@@ -551,6 +586,7 @@ public class WidgetsRef
         {
             return 0;
         }
+
         return ASRNative.Widgets_get_heading_level(this.ptr, (UIntPtr)index);
     }
 
@@ -560,6 +596,7 @@ public class WidgetsRef
         {
             return "";
         }
+
         var ty = ASRNative.Widgets_get_type(this.ptr, (UIntPtr)index);
         switch ((ulong)ty)
         {
@@ -577,10 +614,12 @@ public class WidgetsRef
         {
             return false;
         }
+
         if (settingsMap.ptr == IntPtr.Zero)
         {
             return false;
         }
+
         return ASRNative.Widgets_get_bool(this.ptr, (UIntPtr)index, settingsMap.ptr) != 0;
     }
 
@@ -590,10 +629,12 @@ public class WidgetsRef
         {
             return 0;
         }
+
         if (settingsMap.ptr == IntPtr.Zero)
         {
             return 0;
         }
+
         return (ulong)ASRNative.Widgets_get_choice_current_index(this.ptr, (UIntPtr)index, settingsMap.ptr);
     }
 
@@ -603,6 +644,7 @@ public class WidgetsRef
         {
             return 0;
         }
+
         return (ulong)ASRNative.Widgets_get_choice_options_len(this.ptr, (UIntPtr)index);
     }
 
@@ -612,6 +654,7 @@ public class WidgetsRef
         {
             return "";
         }
+
         return ASRNative.Widgets_get_choice_option_key(this.ptr, (UIntPtr)index, (UIntPtr)optionIndex);
     }
 
@@ -621,6 +664,7 @@ public class WidgetsRef
         {
             return "";
         }
+
         return ASRNative.Widgets_get_choice_option_description(this.ptr, (UIntPtr)index, (UIntPtr)optionIndex);
     }
 
@@ -630,6 +674,7 @@ public class WidgetsRef
         {
             return "";
         }
+
         return ASRNative.Widgets_get_file_select_filter(this.ptr, (UIntPtr)index);
     }
 }
@@ -838,6 +883,7 @@ public class ASRString : SafeHandle
         {
             Marshal.FreeHGlobal(handle);
         }
+
         return true;
     }
 }

--- a/src/LiveSplit.AutoSplittingRuntime/ASR.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASR.cs
@@ -1,852 +1,846 @@
-﻿using LiveSplitCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
+﻿using System;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
+
 using TimeSpan = System.TimeSpan;
 
-namespace LiveSplit.AutoSplittingRuntime
+namespace LiveSplit.AutoSplittingRuntime;
+
+public class RuntimeRef
 {
-    public class RuntimeRef
+    internal IntPtr ptr;
+    internal RuntimeRef(IntPtr ptr)
     {
-        internal IntPtr ptr;
-        internal RuntimeRef(IntPtr ptr)
+        this.ptr = ptr;
+    }
+}
+
+public class RuntimeRefMut : RuntimeRef
+{
+    internal RuntimeRefMut(IntPtr ptr) : base(ptr) { }
+}
+
+public class Runtime : RuntimeRefMut, IDisposable
+{
+    private void Drop()
+    {
+        if (ptr != IntPtr.Zero)
         {
-            this.ptr = ptr;
+            ASRNative.Runtime_drop(this.ptr);
+            ptr = IntPtr.Zero;
         }
     }
-
-    public class RuntimeRefMut : RuntimeRef
+    ~Runtime()
     {
-        internal RuntimeRefMut(IntPtr ptr) : base(ptr) { }
+        Drop();
     }
-
-    public class Runtime : RuntimeRefMut, IDisposable
+    public void Dispose()
     {
-        private void Drop()
+        Drop();
+        GC.SuppressFinalize(this);
+    }
+    public Runtime(
+        string path,
+        SettingsMap settingsMap,
+        StateDelegate state,
+        Action start,
+        Action split,
+        Action skipSplit,
+        Action undoSplit,
+        Action reset,
+        SetGameTimeDelegate setGameTime,
+        Action pauseGameTime,
+        Action resumeGameTime,
+        LogDelegate log
+    ) : base(IntPtr.Zero)
+    {
+        IntPtr settingsMapPtr = settingsMap?.ptr ?? IntPtr.Zero;
+        if (settingsMap != null)
         {
-            if (ptr != IntPtr.Zero)
-            {
-                ASRNative.Runtime_drop(this.ptr);
-                ptr = IntPtr.Zero;
-            }
-        }
-        ~Runtime()
-        {
-            Drop();
-        }
-        public void Dispose()
-        {
-            Drop();
-            GC.SuppressFinalize(this);
-        }
-        public Runtime(
-            string path,
-            SettingsMap settingsMap,
-            StateDelegate state,
-            Action start,
-            Action split,
-            Action skipSplit,
-            Action undoSplit,
-            Action reset,
-            SetGameTimeDelegate setGameTime,
-            Action pauseGameTime,
-            Action resumeGameTime,
-            LogDelegate log
-        ) : base(IntPtr.Zero)
-        {
-            IntPtr settingsMapPtr = settingsMap?.ptr ?? IntPtr.Zero;
-            if (settingsMap != null)
-            {
-                settingsMap.ptr = IntPtr.Zero;
-            }
-            this.ptr = ASRNative.Runtime_new(
-                path,
-                settingsMapPtr,
-                state,
-                start,
-                split,
-                skipSplit,
-                undoSplit,
-                reset,
-                setGameTime,
-                pauseGameTime,
-                resumeGameTime,
-                log
-            );
-            if (this.ptr == IntPtr.Zero)
-            {
-                throw new ArgumentException("Couldn't load the module provided.");
-            }
-        }
-        internal Runtime(IntPtr ptr) : base(ptr) { }
-
-        public bool Step()
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return false;
-            }
-            return ASRNative.Runtime_step(this.ptr);
-        }
-
-        public TimeSpan TickRate()
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return TimeSpan.Zero;
-            }
-            return new TimeSpan((long)ASRNative.Runtime_tick_rate(this.ptr));
-        }
-
-        public Widgets GetSettingsWidgets()
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return null;
-            }
-            return new Widgets(ASRNative.Runtime_get_settings_widgets(this.ptr));
-        }
-
-        public void SettingsMapSetBool(string key, bool value)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return;
-            }
-            ASRNative.Runtime_settings_map_set_bool(this.ptr, key, value ? (byte)1 : (byte)0);
-        }
-
-        public void SettingsMapSetString(string key, string value)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return;
-            }
-            ASRNative.Runtime_settings_map_set_string(this.ptr, key, value);
-        }
-
-        public SettingsMap GetSettingsMap()
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return null;
-            }
-            return new SettingsMap(ASRNative.Runtime_get_settings_map(this.ptr));
-        }
-
-        public void SetSettingsMap(SettingsMap settingsMap)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return;
-            }
-            var settingsMapPtr = settingsMap.ptr;
-            if (settingsMapPtr == IntPtr.Zero)
-            {
-                return;
-            }
             settingsMap.ptr = IntPtr.Zero;
-            ASRNative.Runtime_set_settings_map(this.ptr, settingsMapPtr);
         }
-
-        public bool AreSettingsChanged(SettingsMapRef previousSettingsMap, WidgetsRef previousWidgets)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return false;
-            }
-            if (previousSettingsMap.ptr == IntPtr.Zero)
-            {
-                return false;
-            }
-            if (previousWidgets.ptr == IntPtr.Zero)
-            {
-                return false;
-            }
-            return ASRNative.Runtime_are_settings_changed(this.ptr, previousSettingsMap.ptr, previousWidgets.ptr) != 0;
-        }
-    }
-
-    public class SettingsMapRef
-    {
-        internal IntPtr ptr;
-        internal SettingsMapRef(IntPtr ptr)
-        {
-            this.ptr = ptr;
-        }
-        public ulong GetLength()
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return 0;
-            }
-            return (ulong)ASRNative.SettingsMap_len(this.ptr);
-        }
-        public string GetKey(ulong index)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return "";
-            }
-            return ASRNative.SettingsMap_get_key(this.ptr, (UIntPtr)index);
-        }
-        public SettingValueRef GetValue(ulong index)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return null;
-            }
-            return new SettingValueRef(ASRNative.SettingsMap_get_value(this.ptr, (UIntPtr)index));
-        }
-        public SettingValueRef KeyGetValue(string key)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return null;
-            }
-            var valuePtr = ASRNative.SettingsMap_get_value_by_key(this.ptr, key);
-            if (valuePtr != IntPtr.Zero)
-            {
-                return new SettingValueRef(valuePtr);
-            }
-            else
-            {
-                return null;
-            }
-        }
-    }
-
-    public class SettingsMapRefMut : SettingsMapRef
-    {
-        internal SettingsMapRefMut(IntPtr ptr) : base(ptr) { }
-        public void Insert(string key, SettingValue value)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return;
-            }
-            var valuePtr = value.ptr;
-            if (valuePtr == IntPtr.Zero)
-            {
-                return;
-            }
-            value.ptr = IntPtr.Zero;
-            ASRNative.SettingsMap_insert(this.ptr, key, valuePtr);
-        }
-    }
-
-    public class SettingsMap : SettingsMapRefMut, IDisposable
-    {
-        private void Drop()
-        {
-            if (ptr != IntPtr.Zero)
-            {
-                ASRNative.SettingsMap_drop(this.ptr);
-                ptr = IntPtr.Zero;
-            }
-        }
-        ~SettingsMap()
-        {
-            Drop();
-        }
-        public void Dispose()
-        {
-            Drop();
-            GC.SuppressFinalize(this);
-        }
-        public SettingsMap() : base(IntPtr.Zero)
-        {
-            this.ptr = ASRNative.SettingsMap_new();
-            if (this.ptr == IntPtr.Zero)
-            {
-                throw new ArgumentException("Couldn't create the settings map.");
-            }
-        }
-        internal SettingsMap(IntPtr ptr) : base(ptr) { }
-    }
-
-    public class SettingsListRef
-    {
-        internal IntPtr ptr;
-        internal SettingsListRef(IntPtr ptr)
-        {
-            this.ptr = ptr;
-        }
-        public ulong GetLength()
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return 0;
-            }
-            return (ulong)ASRNative.SettingsList_len(this.ptr);
-        }
-        public SettingValueRef Get(ulong index)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return null;
-            }
-            return new SettingValueRef(ASRNative.SettingsList_get(this.ptr, (UIntPtr)index));
-        }
-    }
-
-    public class SettingsListRefMut : SettingsListRef
-    {
-        internal SettingsListRefMut(IntPtr ptr) : base(ptr) { }
-        public void Push(SettingValue value)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return;
-            }
-            var valuePtr = value.ptr;
-            if (valuePtr == IntPtr.Zero)
-            {
-                return;
-            }
-            value.ptr = IntPtr.Zero;
-            ASRNative.SettingsList_push(this.ptr, valuePtr);
-        }
-    }
-
-    public class SettingsList : SettingsListRefMut, IDisposable
-    {
-        private void Drop()
-        {
-            if (ptr != IntPtr.Zero)
-            {
-                ASRNative.SettingsList_drop(this.ptr);
-                ptr = IntPtr.Zero;
-            }
-        }
-        ~SettingsList()
-        {
-            Drop();
-        }
-        public void Dispose()
-        {
-            Drop();
-            GC.SuppressFinalize(this);
-        }
-        public SettingsList() : base(IntPtr.Zero)
-        {
-            this.ptr = ASRNative.SettingsList_new();
-            if (this.ptr == IntPtr.Zero)
-            {
-                throw new ArgumentException("Couldn't create the settings list.");
-            }
-        }
-        internal SettingsList(IntPtr ptr) : base(ptr) { }
-    }
-
-    public class SettingValueRef
-    {
-        internal IntPtr ptr;
-        internal SettingValueRef(IntPtr ptr)
-        {
-            this.ptr = ptr;
-        }
-        public string GetKind()
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return "";
-            }
-            var ty = ASRNative.SettingValue_get_type(this.ptr);
-            switch ((ulong)ty)
-            {
-                case 1: return "map";
-                case 2: return "list";
-                case 3: return "bool";
-                case 4: return "i64";
-                case 5: return "f64";
-                case 6: return "string";
-                default: return "";
-            }
-        }
-        public SettingsMapRef GetMap()
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return null;
-            }
-            return new SettingsMapRef(ASRNative.SettingValue_get_map(this.ptr));
-        }
-        public SettingsListRef GetList()
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return null;
-            }
-            return new SettingsListRef(ASRNative.SettingValue_get_list(this.ptr));
-        }
-        public bool GetBool()
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return false;
-            }
-            return ASRNative.SettingValue_get_bool(this.ptr) != 0;
-        }
-        public long GetI64()
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return 0;
-            }
-            return ASRNative.SettingValue_get_i64(this.ptr);
-        }
-        public double GetF64()
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return 0;
-            }
-            return ASRNative.SettingValue_get_f64(this.ptr);
-        }
-        public string GetString()
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return "";
-            }
-            return ASRNative.SettingValue_get_string(this.ptr);
-        }
-    }
-
-    public class SettingValueRefMut : SettingValueRef
-    {
-        internal SettingValueRefMut(IntPtr ptr) : base(ptr) { }
-    }
-
-    public class SettingValue : SettingValueRefMut, IDisposable
-    {
-        private void Drop()
-        {
-            if (ptr != IntPtr.Zero)
-            {
-                ASRNative.SettingValue_drop(this.ptr);
-                ptr = IntPtr.Zero;
-            }
-        }
-        ~SettingValue()
-        {
-            Drop();
-        }
-        public void Dispose()
-        {
-            Drop();
-            GC.SuppressFinalize(this);
-        }
-        public SettingValue(bool value) : base(IntPtr.Zero)
-        {
-            this.ptr = ASRNative.SettingValue_new_bool(value ? (byte)1 : (byte)0);
-            if (this.ptr == IntPtr.Zero)
-            {
-                throw new ArgumentException("Couldn't create the setting value.");
-            }
-        }
-        public SettingValue(long value) : base(IntPtr.Zero)
-        {
-            this.ptr = ASRNative.SettingValue_new_i64(value);
-            if (this.ptr == IntPtr.Zero)
-            {
-                throw new ArgumentException("Couldn't create the setting value.");
-            }
-        }
-        public SettingValue(double value) : base(IntPtr.Zero)
-        {
-            this.ptr = ASRNative.SettingValue_new_f64(value);
-            if (this.ptr == IntPtr.Zero)
-            {
-                throw new ArgumentException("Couldn't create the setting value.");
-            }
-        }
-        public SettingValue(string value) : base(IntPtr.Zero)
-        {
-            this.ptr = ASRNative.SettingValue_new_string(value);
-            if (this.ptr == IntPtr.Zero)
-            {
-                throw new ArgumentException("Couldn't create the setting value.");
-            }
-        }
-        public SettingValue(SettingsMap value) : base(IntPtr.Zero)
-        {
-            var valuePtr = value.ptr;
-            if (valuePtr == IntPtr.Zero)
-            {
-                throw new ArgumentException("Couldn't create the setting value.");
-            }
-            value.ptr = IntPtr.Zero;
-            this.ptr = ASRNative.SettingValue_new_map(valuePtr);
-            if (this.ptr == IntPtr.Zero)
-            {
-                throw new ArgumentException("Couldn't create the setting value.");
-            }
-        }
-        public SettingValue(SettingsList value) : base(IntPtr.Zero)
-        {
-            var valuePtr = value.ptr;
-            if (valuePtr == IntPtr.Zero)
-            {
-                throw new ArgumentException("Couldn't create the setting value.");
-            }
-            value.ptr = IntPtr.Zero;
-            this.ptr = ASRNative.SettingValue_new_list(valuePtr);
-            if (this.ptr == IntPtr.Zero)
-            {
-                throw new ArgumentException("Couldn't create the setting value.");
-            }
-        }
-        internal SettingValue(IntPtr ptr) : base(ptr) { }
-    }
-
-    public class WidgetsRef
-    {
-        internal IntPtr ptr;
-        internal WidgetsRef(IntPtr ptr)
-        {
-            this.ptr = ptr;
-        }
-
-        public ulong GetLength()
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return 0;
-            }
-            return (ulong)ASRNative.Widgets_len(this.ptr);
-        }
-
-        public string GetKey(ulong index)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return "";
-            }
-            return ASRNative.Widgets_get_key(this.ptr, (UIntPtr)index);
-        }
-
-        public string GetDescription(ulong index)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return "";
-            }
-            return ASRNative.Widgets_get_description(this.ptr, (UIntPtr)index);
-        }
-
-        public string GetTooltip(ulong index)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return "";
-            }
-            return ASRNative.Widgets_get_tooltip(this.ptr, (UIntPtr)index);
-        }
-
-        public uint GetHeadingLevel(ulong index)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return 0;
-            }
-            return ASRNative.Widgets_get_heading_level(this.ptr, (UIntPtr)index);
-        }
-
-        public string GetType(ulong index)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return "";
-            }
-            var ty = ASRNative.Widgets_get_type(this.ptr, (UIntPtr)index);
-            switch ((ulong)ty)
-            {
-                case 1: return "bool";
-                case 2: return "title";
-                case 3: return "choice";
-                case 4: return "file-select";
-                default: return "";
-            }
-        }
-
-        public bool GetBool(ulong index, SettingsMapRef settingsMap)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return false;
-            }
-            if (settingsMap.ptr == IntPtr.Zero)
-            {
-                return false;
-            }
-            return ASRNative.Widgets_get_bool(this.ptr, (UIntPtr)index, settingsMap.ptr) != 0;
-        }
-
-        public ulong GetChoiceCurrentIndex(ulong index, SettingsMapRef settingsMap)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return 0;
-            }
-            if (settingsMap.ptr == IntPtr.Zero)
-            {
-                return 0;
-            }
-            return (ulong)ASRNative.Widgets_get_choice_current_index(this.ptr, (UIntPtr)index, settingsMap.ptr);
-        }
-
-        public ulong GetChoiceOptionsLength(ulong index)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return 0;
-            }
-            return (ulong)ASRNative.Widgets_get_choice_options_len(this.ptr, (UIntPtr)index);
-        }
-
-        public string GetChoiceOptionKey(ulong index, ulong optionIndex)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return "";
-            }
-            return ASRNative.Widgets_get_choice_option_key(this.ptr, (UIntPtr)index, (UIntPtr)optionIndex);
-        }
-
-        public string GetChoiceOptionDescription(ulong index, ulong optionIndex)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return "";
-            }
-            return ASRNative.Widgets_get_choice_option_description(this.ptr, (UIntPtr)index, (UIntPtr)optionIndex);
-        }
-
-        public string GetFileSelectFilter(ulong index)
-        {
-            if (ptr == IntPtr.Zero)
-            {
-                return "";
-            }
-            return ASRNative.Widgets_get_file_select_filter(this.ptr, (UIntPtr)index);
-        }
-    }
-
-    public class WidgetsRefMut : WidgetsRef
-    {
-        internal WidgetsRefMut(IntPtr ptr) : base(ptr) { }
-    }
-
-    public class Widgets : WidgetsRefMut, IDisposable
-    {
-        private void Drop()
-        {
-            if (ptr != IntPtr.Zero)
-            {
-                ASRNative.Widgets_drop(this.ptr);
-                ptr = IntPtr.Zero;
-            }
-        }
-        ~Widgets()
-        {
-            Drop();
-        }
-        public void Dispose()
-        {
-            Drop();
-            GC.SuppressFinalize(this);
-        }
-        internal Widgets(IntPtr ptr) : base(ptr) { }
-    }
-
-    public delegate int StateDelegate();
-    public delegate void SetGameTimeDelegate(long gameTime);
-    public delegate void LogDelegate(IntPtr messagePtr, UIntPtr messageLen);
-
-    public static class ASRNative
-    {
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr Runtime_new(
-            ASRString path,
-            IntPtr settings_map,
-            StateDelegate state,
-            Action start,
-            Action split,
-            Action skipSplit,
-            Action undoSplit,
-            Action reset,
-            SetGameTimeDelegate set_game_time,
-            Action pause_game_time,
-            Action resume_game_time,
-            LogDelegate log
+        this.ptr = ASRNative.Runtime_new(
+            path,
+            settingsMapPtr,
+            state,
+            start,
+            split,
+            skipSplit,
+            undoSplit,
+            reset,
+            setGameTime,
+            pauseGameTime,
+            resumeGameTime,
+            log
         );
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void Runtime_drop(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern bool Runtime_step(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern ulong Runtime_tick_rate(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr Runtime_get_settings_widgets(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void Runtime_settings_map_set_bool(IntPtr self, ASRString key, byte value);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void Runtime_settings_map_set_string(IntPtr self, ASRString key, ASRString value);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr Runtime_get_settings_map(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void Runtime_set_settings_map(IntPtr self, IntPtr settings_map);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern byte Runtime_are_settings_changed(IntPtr self, IntPtr previous_settings_map, IntPtr previous_widgets);
-
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr SettingsMap_new();
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void SettingsMap_drop(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void SettingsMap_insert(IntPtr self, ASRString key, IntPtr value);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern UIntPtr SettingsMap_len(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern ASRString SettingsMap_get_key(IntPtr self, UIntPtr index);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr SettingsMap_get_value(IntPtr self, UIntPtr index);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr SettingsMap_get_value_by_key(IntPtr self, ASRString key);
-
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr SettingsList_new();
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void SettingsList_drop(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void SettingsList_push(IntPtr self, IntPtr value);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern UIntPtr SettingsList_len(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr SettingsList_get(IntPtr self, UIntPtr index);
-
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr SettingValue_new_map(IntPtr value);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr SettingValue_new_list(IntPtr value);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr SettingValue_new_bool(byte value);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr SettingValue_new_i64(long value);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr SettingValue_new_f64(double value);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr SettingValue_new_string(ASRString value);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void SettingValue_drop(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern UIntPtr SettingValue_get_type(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr SettingValue_get_map(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr SettingValue_get_list(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern byte SettingValue_get_bool(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern long SettingValue_get_i64(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern double SettingValue_get_f64(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern ASRString SettingValue_get_string(IntPtr self);
-
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void Widgets_drop(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern UIntPtr Widgets_len(IntPtr self);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern ASRString Widgets_get_key(IntPtr self, UIntPtr index);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern ASRString Widgets_get_description(IntPtr self, UIntPtr index);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern ASRString Widgets_get_tooltip(IntPtr self, UIntPtr index);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern uint Widgets_get_heading_level(IntPtr self, UIntPtr index);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern UIntPtr Widgets_get_type(IntPtr self, UIntPtr index);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern byte Widgets_get_bool(IntPtr self, UIntPtr index, IntPtr settings_map);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern UIntPtr Widgets_get_choice_current_index(IntPtr self, UIntPtr index, IntPtr settings_map);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern UIntPtr Widgets_get_choice_options_len(IntPtr self, UIntPtr index);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern ASRString Widgets_get_choice_option_key(IntPtr self, UIntPtr index, UIntPtr option_index);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern ASRString Widgets_get_choice_option_description(IntPtr self, UIntPtr index, UIntPtr option_index);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern ASRString Widgets_get_file_select_filter(IntPtr self, UIntPtr index);
-
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern UIntPtr get_buf_len();
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern ASRString path_to_wasi(ASRString original_path);
-        [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-        public static extern ASRString wasi_to_path(ASRString wasi_path);
+        if (this.ptr == IntPtr.Zero)
+        {
+            throw new ArgumentException("Couldn't load the module provided.");
+        }
     }
+    internal Runtime(IntPtr ptr) : base(ptr) { }
 
-    public class ASRString : SafeHandle
+    public bool Step()
     {
-        private bool needToFree;
-
-        public ASRString() : base(IntPtr.Zero, false) { }
-
-        public override bool IsInvalid
+        if (ptr == IntPtr.Zero)
         {
-            get { return false; }
+            return false;
         }
+        return ASRNative.Runtime_step(this.ptr);
+    }
 
-        public static implicit operator ASRString(string managedString)
+    public TimeSpan TickRate()
+    {
+        if (ptr == IntPtr.Zero)
         {
-            ASRString asrString = new ASRString();
-
-            int len = Encoding.UTF8.GetByteCount(managedString);
-            byte[] buffer = new byte[len + 1];
-            Encoding.UTF8.GetBytes(managedString, 0, managedString.Length, buffer, 0);
-            IntPtr nativeUtf8 = Marshal.AllocHGlobal(buffer.Length);
-            Marshal.Copy(buffer, 0, nativeUtf8, buffer.Length);
-
-            asrString.SetHandle(nativeUtf8);
-            asrString.needToFree = true;
-            return asrString;
+            return TimeSpan.Zero;
         }
+        return new TimeSpan((long)ASRNative.Runtime_tick_rate(this.ptr));
+    }
 
-        public static string FromPtrLen(IntPtr ptr, UIntPtr len)
+    public Widgets GetSettingsWidgets()
+    {
+        if (ptr == IntPtr.Zero)
         {
-            if (ptr == IntPtr.Zero || (ulong)len > (ulong)int.MaxValue)
-            {
-                return null;
-            }
-
-            unsafe
-            {
-                return Encoding.UTF8.GetString((byte*)ptr, (int)len);
-            }
+            return null;
         }
+        return new Widgets(ASRNative.Runtime_get_settings_widgets(this.ptr));
+    }
 
-        public static implicit operator string(ASRString asrString)
+    public void SettingsMapSetBool(string key, bool value)
+    {
+        if (ptr == IntPtr.Zero)
         {
-            return FromPtrLen(asrString.handle, ASRNative.get_buf_len());
+            return;
         }
+        ASRNative.Runtime_settings_map_set_bool(this.ptr, key, value ? (byte)1 : (byte)0);
+    }
 
-        protected override bool ReleaseHandle()
+    public void SettingsMapSetString(string key, string value)
+    {
+        if (ptr == IntPtr.Zero)
         {
-            if (needToFree)
-            {
-                Marshal.FreeHGlobal(handle);
-            }
-            return true;
+            return;
+        }
+        ASRNative.Runtime_settings_map_set_string(this.ptr, key, value);
+    }
+
+    public SettingsMap GetSettingsMap()
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return null;
+        }
+        return new SettingsMap(ASRNative.Runtime_get_settings_map(this.ptr));
+    }
+
+    public void SetSettingsMap(SettingsMap settingsMap)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return;
+        }
+        var settingsMapPtr = settingsMap.ptr;
+        if (settingsMapPtr == IntPtr.Zero)
+        {
+            return;
+        }
+        settingsMap.ptr = IntPtr.Zero;
+        ASRNative.Runtime_set_settings_map(this.ptr, settingsMapPtr);
+    }
+
+    public bool AreSettingsChanged(SettingsMapRef previousSettingsMap, WidgetsRef previousWidgets)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return false;
+        }
+        if (previousSettingsMap.ptr == IntPtr.Zero)
+        {
+            return false;
+        }
+        if (previousWidgets.ptr == IntPtr.Zero)
+        {
+            return false;
+        }
+        return ASRNative.Runtime_are_settings_changed(this.ptr, previousSettingsMap.ptr, previousWidgets.ptr) != 0;
+    }
+}
+
+public class SettingsMapRef
+{
+    internal IntPtr ptr;
+    internal SettingsMapRef(IntPtr ptr)
+    {
+        this.ptr = ptr;
+    }
+    public ulong GetLength()
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return 0;
+        }
+        return (ulong)ASRNative.SettingsMap_len(this.ptr);
+    }
+    public string GetKey(ulong index)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return "";
+        }
+        return ASRNative.SettingsMap_get_key(this.ptr, (UIntPtr)index);
+    }
+    public SettingValueRef GetValue(ulong index)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return null;
+        }
+        return new SettingValueRef(ASRNative.SettingsMap_get_value(this.ptr, (UIntPtr)index));
+    }
+    public SettingValueRef KeyGetValue(string key)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return null;
+        }
+        var valuePtr = ASRNative.SettingsMap_get_value_by_key(this.ptr, key);
+        if (valuePtr != IntPtr.Zero)
+        {
+            return new SettingValueRef(valuePtr);
+        }
+        else
+        {
+            return null;
+        }
+    }
+}
+
+public class SettingsMapRefMut : SettingsMapRef
+{
+    internal SettingsMapRefMut(IntPtr ptr) : base(ptr) { }
+    public void Insert(string key, SettingValue value)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return;
+        }
+        var valuePtr = value.ptr;
+        if (valuePtr == IntPtr.Zero)
+        {
+            return;
+        }
+        value.ptr = IntPtr.Zero;
+        ASRNative.SettingsMap_insert(this.ptr, key, valuePtr);
+    }
+}
+
+public class SettingsMap : SettingsMapRefMut, IDisposable
+{
+    private void Drop()
+    {
+        if (ptr != IntPtr.Zero)
+        {
+            ASRNative.SettingsMap_drop(this.ptr);
+            ptr = IntPtr.Zero;
+        }
+    }
+    ~SettingsMap()
+    {
+        Drop();
+    }
+    public void Dispose()
+    {
+        Drop();
+        GC.SuppressFinalize(this);
+    }
+    public SettingsMap() : base(IntPtr.Zero)
+    {
+        this.ptr = ASRNative.SettingsMap_new();
+        if (this.ptr == IntPtr.Zero)
+        {
+            throw new ArgumentException("Couldn't create the settings map.");
+        }
+    }
+    internal SettingsMap(IntPtr ptr) : base(ptr) { }
+}
+
+public class SettingsListRef
+{
+    internal IntPtr ptr;
+    internal SettingsListRef(IntPtr ptr)
+    {
+        this.ptr = ptr;
+    }
+    public ulong GetLength()
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return 0;
+        }
+        return (ulong)ASRNative.SettingsList_len(this.ptr);
+    }
+    public SettingValueRef Get(ulong index)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return null;
+        }
+        return new SettingValueRef(ASRNative.SettingsList_get(this.ptr, (UIntPtr)index));
+    }
+}
+
+public class SettingsListRefMut : SettingsListRef
+{
+    internal SettingsListRefMut(IntPtr ptr) : base(ptr) { }
+    public void Push(SettingValue value)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return;
+        }
+        var valuePtr = value.ptr;
+        if (valuePtr == IntPtr.Zero)
+        {
+            return;
+        }
+        value.ptr = IntPtr.Zero;
+        ASRNative.SettingsList_push(this.ptr, valuePtr);
+    }
+}
+
+public class SettingsList : SettingsListRefMut, IDisposable
+{
+    private void Drop()
+    {
+        if (ptr != IntPtr.Zero)
+        {
+            ASRNative.SettingsList_drop(this.ptr);
+            ptr = IntPtr.Zero;
+        }
+    }
+    ~SettingsList()
+    {
+        Drop();
+    }
+    public void Dispose()
+    {
+        Drop();
+        GC.SuppressFinalize(this);
+    }
+    public SettingsList() : base(IntPtr.Zero)
+    {
+        this.ptr = ASRNative.SettingsList_new();
+        if (this.ptr == IntPtr.Zero)
+        {
+            throw new ArgumentException("Couldn't create the settings list.");
+        }
+    }
+    internal SettingsList(IntPtr ptr) : base(ptr) { }
+}
+
+public class SettingValueRef
+{
+    internal IntPtr ptr;
+    internal SettingValueRef(IntPtr ptr)
+    {
+        this.ptr = ptr;
+    }
+    public string GetKind()
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return "";
+        }
+        var ty = ASRNative.SettingValue_get_type(this.ptr);
+        switch ((ulong)ty)
+        {
+            case 1: return "map";
+            case 2: return "list";
+            case 3: return "bool";
+            case 4: return "i64";
+            case 5: return "f64";
+            case 6: return "string";
+            default: return "";
+        }
+    }
+    public SettingsMapRef GetMap()
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return null;
+        }
+        return new SettingsMapRef(ASRNative.SettingValue_get_map(this.ptr));
+    }
+    public SettingsListRef GetList()
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return null;
+        }
+        return new SettingsListRef(ASRNative.SettingValue_get_list(this.ptr));
+    }
+    public bool GetBool()
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return false;
+        }
+        return ASRNative.SettingValue_get_bool(this.ptr) != 0;
+    }
+    public long GetI64()
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return 0;
+        }
+        return ASRNative.SettingValue_get_i64(this.ptr);
+    }
+    public double GetF64()
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return 0;
+        }
+        return ASRNative.SettingValue_get_f64(this.ptr);
+    }
+    public string GetString()
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return "";
+        }
+        return ASRNative.SettingValue_get_string(this.ptr);
+    }
+}
+
+public class SettingValueRefMut : SettingValueRef
+{
+    internal SettingValueRefMut(IntPtr ptr) : base(ptr) { }
+}
+
+public class SettingValue : SettingValueRefMut, IDisposable
+{
+    private void Drop()
+    {
+        if (ptr != IntPtr.Zero)
+        {
+            ASRNative.SettingValue_drop(this.ptr);
+            ptr = IntPtr.Zero;
+        }
+    }
+    ~SettingValue()
+    {
+        Drop();
+    }
+    public void Dispose()
+    {
+        Drop();
+        GC.SuppressFinalize(this);
+    }
+    public SettingValue(bool value) : base(IntPtr.Zero)
+    {
+        this.ptr = ASRNative.SettingValue_new_bool(value ? (byte)1 : (byte)0);
+        if (this.ptr == IntPtr.Zero)
+        {
+            throw new ArgumentException("Couldn't create the setting value.");
+        }
+    }
+    public SettingValue(long value) : base(IntPtr.Zero)
+    {
+        this.ptr = ASRNative.SettingValue_new_i64(value);
+        if (this.ptr == IntPtr.Zero)
+        {
+            throw new ArgumentException("Couldn't create the setting value.");
+        }
+    }
+    public SettingValue(double value) : base(IntPtr.Zero)
+    {
+        this.ptr = ASRNative.SettingValue_new_f64(value);
+        if (this.ptr == IntPtr.Zero)
+        {
+            throw new ArgumentException("Couldn't create the setting value.");
+        }
+    }
+    public SettingValue(string value) : base(IntPtr.Zero)
+    {
+        this.ptr = ASRNative.SettingValue_new_string(value);
+        if (this.ptr == IntPtr.Zero)
+        {
+            throw new ArgumentException("Couldn't create the setting value.");
+        }
+    }
+    public SettingValue(SettingsMap value) : base(IntPtr.Zero)
+    {
+        var valuePtr = value.ptr;
+        if (valuePtr == IntPtr.Zero)
+        {
+            throw new ArgumentException("Couldn't create the setting value.");
+        }
+        value.ptr = IntPtr.Zero;
+        this.ptr = ASRNative.SettingValue_new_map(valuePtr);
+        if (this.ptr == IntPtr.Zero)
+        {
+            throw new ArgumentException("Couldn't create the setting value.");
+        }
+    }
+    public SettingValue(SettingsList value) : base(IntPtr.Zero)
+    {
+        var valuePtr = value.ptr;
+        if (valuePtr == IntPtr.Zero)
+        {
+            throw new ArgumentException("Couldn't create the setting value.");
+        }
+        value.ptr = IntPtr.Zero;
+        this.ptr = ASRNative.SettingValue_new_list(valuePtr);
+        if (this.ptr == IntPtr.Zero)
+        {
+            throw new ArgumentException("Couldn't create the setting value.");
+        }
+    }
+    internal SettingValue(IntPtr ptr) : base(ptr) { }
+}
+
+public class WidgetsRef
+{
+    internal IntPtr ptr;
+    internal WidgetsRef(IntPtr ptr)
+    {
+        this.ptr = ptr;
+    }
+
+    public ulong GetLength()
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return 0;
+        }
+        return (ulong)ASRNative.Widgets_len(this.ptr);
+    }
+
+    public string GetKey(ulong index)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return "";
+        }
+        return ASRNative.Widgets_get_key(this.ptr, (UIntPtr)index);
+    }
+
+    public string GetDescription(ulong index)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return "";
+        }
+        return ASRNative.Widgets_get_description(this.ptr, (UIntPtr)index);
+    }
+
+    public string GetTooltip(ulong index)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return "";
+        }
+        return ASRNative.Widgets_get_tooltip(this.ptr, (UIntPtr)index);
+    }
+
+    public uint GetHeadingLevel(ulong index)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return 0;
+        }
+        return ASRNative.Widgets_get_heading_level(this.ptr, (UIntPtr)index);
+    }
+
+    public string GetType(ulong index)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return "";
+        }
+        var ty = ASRNative.Widgets_get_type(this.ptr, (UIntPtr)index);
+        switch ((ulong)ty)
+        {
+            case 1: return "bool";
+            case 2: return "title";
+            case 3: return "choice";
+            case 4: return "file-select";
+            default: return "";
         }
     }
 
+    public bool GetBool(ulong index, SettingsMapRef settingsMap)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return false;
+        }
+        if (settingsMap.ptr == IntPtr.Zero)
+        {
+            return false;
+        }
+        return ASRNative.Widgets_get_bool(this.ptr, (UIntPtr)index, settingsMap.ptr) != 0;
+    }
+
+    public ulong GetChoiceCurrentIndex(ulong index, SettingsMapRef settingsMap)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return 0;
+        }
+        if (settingsMap.ptr == IntPtr.Zero)
+        {
+            return 0;
+        }
+        return (ulong)ASRNative.Widgets_get_choice_current_index(this.ptr, (UIntPtr)index, settingsMap.ptr);
+    }
+
+    public ulong GetChoiceOptionsLength(ulong index)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return 0;
+        }
+        return (ulong)ASRNative.Widgets_get_choice_options_len(this.ptr, (UIntPtr)index);
+    }
+
+    public string GetChoiceOptionKey(ulong index, ulong optionIndex)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return "";
+        }
+        return ASRNative.Widgets_get_choice_option_key(this.ptr, (UIntPtr)index, (UIntPtr)optionIndex);
+    }
+
+    public string GetChoiceOptionDescription(ulong index, ulong optionIndex)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return "";
+        }
+        return ASRNative.Widgets_get_choice_option_description(this.ptr, (UIntPtr)index, (UIntPtr)optionIndex);
+    }
+
+    public string GetFileSelectFilter(ulong index)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return "";
+        }
+        return ASRNative.Widgets_get_file_select_filter(this.ptr, (UIntPtr)index);
+    }
+}
+
+public class WidgetsRefMut : WidgetsRef
+{
+    internal WidgetsRefMut(IntPtr ptr) : base(ptr) { }
+}
+
+public class Widgets : WidgetsRefMut, IDisposable
+{
+    private void Drop()
+    {
+        if (ptr != IntPtr.Zero)
+        {
+            ASRNative.Widgets_drop(this.ptr);
+            ptr = IntPtr.Zero;
+        }
+    }
+    ~Widgets()
+    {
+        Drop();
+    }
+    public void Dispose()
+    {
+        Drop();
+        GC.SuppressFinalize(this);
+    }
+    internal Widgets(IntPtr ptr) : base(ptr) { }
+}
+
+public delegate int StateDelegate();
+public delegate void SetGameTimeDelegate(long gameTime);
+public delegate void LogDelegate(IntPtr messagePtr, UIntPtr messageLen);
+
+public static class ASRNative
+{
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr Runtime_new(
+        ASRString path,
+        IntPtr settings_map,
+        StateDelegate state,
+        Action start,
+        Action split,
+        Action skipSplit,
+        Action undoSplit,
+        Action reset,
+        SetGameTimeDelegate set_game_time,
+        Action pause_game_time,
+        Action resume_game_time,
+        LogDelegate log
+    );
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void Runtime_drop(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern bool Runtime_step(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern ulong Runtime_tick_rate(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr Runtime_get_settings_widgets(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void Runtime_settings_map_set_bool(IntPtr self, ASRString key, byte value);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void Runtime_settings_map_set_string(IntPtr self, ASRString key, ASRString value);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr Runtime_get_settings_map(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void Runtime_set_settings_map(IntPtr self, IntPtr settings_map);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern byte Runtime_are_settings_changed(IntPtr self, IntPtr previous_settings_map, IntPtr previous_widgets);
+
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr SettingsMap_new();
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void SettingsMap_drop(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void SettingsMap_insert(IntPtr self, ASRString key, IntPtr value);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern UIntPtr SettingsMap_len(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern ASRString SettingsMap_get_key(IntPtr self, UIntPtr index);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr SettingsMap_get_value(IntPtr self, UIntPtr index);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr SettingsMap_get_value_by_key(IntPtr self, ASRString key);
+
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr SettingsList_new();
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void SettingsList_drop(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void SettingsList_push(IntPtr self, IntPtr value);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern UIntPtr SettingsList_len(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr SettingsList_get(IntPtr self, UIntPtr index);
+
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr SettingValue_new_map(IntPtr value);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr SettingValue_new_list(IntPtr value);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr SettingValue_new_bool(byte value);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr SettingValue_new_i64(long value);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr SettingValue_new_f64(double value);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr SettingValue_new_string(ASRString value);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void SettingValue_drop(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern UIntPtr SettingValue_get_type(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr SettingValue_get_map(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern IntPtr SettingValue_get_list(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern byte SettingValue_get_bool(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern long SettingValue_get_i64(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern double SettingValue_get_f64(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern ASRString SettingValue_get_string(IntPtr self);
+
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern void Widgets_drop(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern UIntPtr Widgets_len(IntPtr self);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern ASRString Widgets_get_key(IntPtr self, UIntPtr index);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern ASRString Widgets_get_description(IntPtr self, UIntPtr index);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern ASRString Widgets_get_tooltip(IntPtr self, UIntPtr index);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern uint Widgets_get_heading_level(IntPtr self, UIntPtr index);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern UIntPtr Widgets_get_type(IntPtr self, UIntPtr index);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern byte Widgets_get_bool(IntPtr self, UIntPtr index, IntPtr settings_map);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern UIntPtr Widgets_get_choice_current_index(IntPtr self, UIntPtr index, IntPtr settings_map);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern UIntPtr Widgets_get_choice_options_len(IntPtr self, UIntPtr index);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern ASRString Widgets_get_choice_option_key(IntPtr self, UIntPtr index, UIntPtr option_index);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern ASRString Widgets_get_choice_option_description(IntPtr self, UIntPtr index, UIntPtr option_index);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern ASRString Widgets_get_file_select_filter(IntPtr self, UIntPtr index);
+
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern UIntPtr get_buf_len();
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern ASRString path_to_wasi(ASRString original_path);
+    [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern ASRString wasi_to_path(ASRString wasi_path);
+}
+
+public class ASRString : SafeHandle
+{
+    private bool needToFree;
+
+    public ASRString() : base(IntPtr.Zero, false) { }
+
+    public override bool IsInvalid
+    {
+        get { return false; }
+    }
+
+    public static implicit operator ASRString(string managedString)
+    {
+        ASRString asrString = new ASRString();
+
+        int len = Encoding.UTF8.GetByteCount(managedString);
+        byte[] buffer = new byte[len + 1];
+        Encoding.UTF8.GetBytes(managedString, 0, managedString.Length, buffer, 0);
+        IntPtr nativeUtf8 = Marshal.AllocHGlobal(buffer.Length);
+        Marshal.Copy(buffer, 0, nativeUtf8, buffer.Length);
+
+        asrString.SetHandle(nativeUtf8);
+        asrString.needToFree = true;
+        return asrString;
+    }
+
+    public static string FromPtrLen(IntPtr ptr, UIntPtr len)
+    {
+        if (ptr == IntPtr.Zero || (ulong)len > (ulong)int.MaxValue)
+        {
+            return null;
+        }
+
+        unsafe
+        {
+            return Encoding.UTF8.GetString((byte*)ptr, (int)len);
+        }
+    }
+
+    public static implicit operator string(ASRString asrString)
+    {
+        return FromPtrLen(asrString.handle, ASRNative.get_buf_len());
+    }
+
+    protected override bool ReleaseHandle()
+    {
+        if (needToFree)
+        {
+            Marshal.FreeHGlobal(handle);
+        }
+        return true;
+    }
 }

--- a/src/LiveSplit.AutoSplittingRuntime/ASR.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASR.cs
@@ -8,8 +8,8 @@ namespace LiveSplit.AutoSplittingRuntime;
 
 public class RuntimeRef
 {
-    internal IntPtr ptr;
-    internal RuntimeRef(IntPtr ptr)
+    internal nint ptr;
+    internal RuntimeRef(nint ptr)
     {
         this.ptr = ptr;
     }
@@ -17,17 +17,17 @@ public class RuntimeRef
 
 public class RuntimeRefMut : RuntimeRef
 {
-    internal RuntimeRefMut(IntPtr ptr) : base(ptr) { }
+    internal RuntimeRefMut(nint ptr) : base(ptr) { }
 }
 
 public class Runtime : RuntimeRefMut, IDisposable
 {
     private void Drop()
     {
-        if (ptr != IntPtr.Zero)
+        if (ptr != 0)
         {
             ASRNative.Runtime_drop(ptr);
-            ptr = IntPtr.Zero;
+            ptr = 0;
         }
     }
     ~Runtime()
@@ -52,12 +52,12 @@ public class Runtime : RuntimeRefMut, IDisposable
         Action pauseGameTime,
         Action resumeGameTime,
         LogDelegate log
-    ) : base(IntPtr.Zero)
+    ) : base(0)
     {
-        IntPtr settingsMapPtr = settingsMap?.ptr ?? IntPtr.Zero;
+        nint settingsMapPtr = settingsMap?.ptr ?? 0;
         if (settingsMap != null)
         {
-            settingsMap.ptr = IntPtr.Zero;
+            settingsMap.ptr = 0;
         }
 
         ptr = ASRNative.Runtime_new(
@@ -74,16 +74,16 @@ public class Runtime : RuntimeRefMut, IDisposable
             resumeGameTime,
             log
         );
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             throw new ArgumentException("Couldn't load the module provided.");
         }
     }
-    internal Runtime(IntPtr ptr) : base(ptr) { }
+    internal Runtime(nint ptr) : base(ptr) { }
 
     public bool Step()
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return false;
         }
@@ -93,7 +93,7 @@ public class Runtime : RuntimeRefMut, IDisposable
 
     public TimeSpan TickRate()
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return TimeSpan.Zero;
         }
@@ -103,7 +103,7 @@ public class Runtime : RuntimeRefMut, IDisposable
 
     public Widgets GetSettingsWidgets()
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return null;
         }
@@ -113,7 +113,7 @@ public class Runtime : RuntimeRefMut, IDisposable
 
     public void SettingsMapSetBool(string key, bool value)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return;
         }
@@ -123,7 +123,7 @@ public class Runtime : RuntimeRefMut, IDisposable
 
     public void SettingsMapSetString(string key, string value)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return;
         }
@@ -133,7 +133,7 @@ public class Runtime : RuntimeRefMut, IDisposable
 
     public SettingsMap GetSettingsMap()
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return null;
         }
@@ -143,34 +143,34 @@ public class Runtime : RuntimeRefMut, IDisposable
 
     public void SetSettingsMap(SettingsMap settingsMap)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return;
         }
 
-        IntPtr settingsMapPtr = settingsMap.ptr;
-        if (settingsMapPtr == IntPtr.Zero)
+        nint settingsMapPtr = settingsMap.ptr;
+        if (settingsMapPtr == 0)
         {
             return;
         }
 
-        settingsMap.ptr = IntPtr.Zero;
+        settingsMap.ptr = 0;
         ASRNative.Runtime_set_settings_map(ptr, settingsMapPtr);
     }
 
     public bool AreSettingsChanged(SettingsMapRef previousSettingsMap, WidgetsRef previousWidgets)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return false;
         }
 
-        if (previousSettingsMap.ptr == IntPtr.Zero)
+        if (previousSettingsMap.ptr == 0)
         {
             return false;
         }
 
-        if (previousWidgets.ptr == IntPtr.Zero)
+        if (previousWidgets.ptr == 0)
         {
             return false;
         }
@@ -181,47 +181,47 @@ public class Runtime : RuntimeRefMut, IDisposable
 
 public class SettingsMapRef
 {
-    internal IntPtr ptr;
-    internal SettingsMapRef(IntPtr ptr)
+    internal nint ptr;
+    internal SettingsMapRef(nint ptr)
     {
         this.ptr = ptr;
     }
     public ulong GetLength()
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return 0;
         }
 
-        return (ulong)ASRNative.SettingsMap_len(ptr);
+        return ASRNative.SettingsMap_len(ptr);
     }
     public string GetKey(ulong index)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return "";
         }
 
-        return ASRNative.SettingsMap_get_key(ptr, (UIntPtr)index);
+        return ASRNative.SettingsMap_get_key(ptr, (nuint)index);
     }
     public SettingValueRef GetValue(ulong index)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return null;
         }
 
-        return new SettingValueRef(ASRNative.SettingsMap_get_value(ptr, (UIntPtr)index));
+        return new SettingValueRef(ASRNative.SettingsMap_get_value(ptr, (nuint)index));
     }
     public SettingValueRef KeyGetValue(string key)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return null;
         }
 
-        IntPtr valuePtr = ASRNative.SettingsMap_get_value_by_key(ptr, key);
-        if (valuePtr != IntPtr.Zero)
+        nint valuePtr = ASRNative.SettingsMap_get_value_by_key(ptr, key);
+        if (valuePtr != 0)
         {
             return new SettingValueRef(valuePtr);
         }
@@ -234,21 +234,21 @@ public class SettingsMapRef
 
 public class SettingsMapRefMut : SettingsMapRef
 {
-    internal SettingsMapRefMut(IntPtr ptr) : base(ptr) { }
+    internal SettingsMapRefMut(nint ptr) : base(ptr) { }
     public void Insert(string key, SettingValue value)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return;
         }
 
-        IntPtr valuePtr = value.ptr;
-        if (valuePtr == IntPtr.Zero)
+        nint valuePtr = value.ptr;
+        if (valuePtr == 0)
         {
             return;
         }
 
-        value.ptr = IntPtr.Zero;
+        value.ptr = 0;
         ASRNative.SettingsMap_insert(ptr, key, valuePtr);
     }
 }
@@ -257,10 +257,10 @@ public class SettingsMap : SettingsMapRefMut, IDisposable
 {
     private void Drop()
     {
-        if (ptr != IntPtr.Zero)
+        if (ptr != 0)
         {
             ASRNative.SettingsMap_drop(ptr);
-            ptr = IntPtr.Zero;
+            ptr = 0;
         }
     }
     ~SettingsMap()
@@ -272,61 +272,61 @@ public class SettingsMap : SettingsMapRefMut, IDisposable
         Drop();
         GC.SuppressFinalize(this);
     }
-    public SettingsMap() : base(IntPtr.Zero)
+    public SettingsMap() : base(0)
     {
         ptr = ASRNative.SettingsMap_new();
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             throw new ArgumentException("Couldn't create the settings map.");
         }
     }
-    internal SettingsMap(IntPtr ptr) : base(ptr) { }
+    internal SettingsMap(nint ptr) : base(ptr) { }
 }
 
 public class SettingsListRef
 {
-    internal IntPtr ptr;
-    internal SettingsListRef(IntPtr ptr)
+    internal nint ptr;
+    internal SettingsListRef(nint ptr)
     {
         this.ptr = ptr;
     }
     public ulong GetLength()
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return 0;
         }
 
-        return (ulong)ASRNative.SettingsList_len(ptr);
+        return ASRNative.SettingsList_len(ptr);
     }
     public SettingValueRef Get(ulong index)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return null;
         }
 
-        return new SettingValueRef(ASRNative.SettingsList_get(ptr, (UIntPtr)index));
+        return new SettingValueRef(ASRNative.SettingsList_get(ptr, (nuint)index));
     }
 }
 
 public class SettingsListRefMut : SettingsListRef
 {
-    internal SettingsListRefMut(IntPtr ptr) : base(ptr) { }
+    internal SettingsListRefMut(nint ptr) : base(ptr) { }
     public void Push(SettingValue value)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return;
         }
 
-        IntPtr valuePtr = value.ptr;
-        if (valuePtr == IntPtr.Zero)
+        nint valuePtr = value.ptr;
+        if (valuePtr == 0)
         {
             return;
         }
 
-        value.ptr = IntPtr.Zero;
+        value.ptr = 0;
         ASRNative.SettingsList_push(ptr, valuePtr);
     }
 }
@@ -335,10 +335,10 @@ public class SettingsList : SettingsListRefMut, IDisposable
 {
     private void Drop()
     {
-        if (ptr != IntPtr.Zero)
+        if (ptr != 0)
         {
             ASRNative.SettingsList_drop(ptr);
-            ptr = IntPtr.Zero;
+            ptr = 0;
         }
     }
     ~SettingsList()
@@ -350,32 +350,32 @@ public class SettingsList : SettingsListRefMut, IDisposable
         Drop();
         GC.SuppressFinalize(this);
     }
-    public SettingsList() : base(IntPtr.Zero)
+    public SettingsList() : base(0)
     {
         ptr = ASRNative.SettingsList_new();
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             throw new ArgumentException("Couldn't create the settings list.");
         }
     }
-    internal SettingsList(IntPtr ptr) : base(ptr) { }
+    internal SettingsList(nint ptr) : base(ptr) { }
 }
 
 public class SettingValueRef
 {
-    internal IntPtr ptr;
-    internal SettingValueRef(IntPtr ptr)
+    internal nint ptr;
+    internal SettingValueRef(nint ptr)
     {
         this.ptr = ptr;
     }
     public string GetKind()
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return "";
         }
 
-        UIntPtr ty = ASRNative.SettingValue_get_type(ptr);
+        nuint ty = ASRNative.SettingValue_get_type(ptr);
         return (ulong)ty switch
         {
             1 => "map",
@@ -389,7 +389,7 @@ public class SettingValueRef
     }
     public SettingsMapRef GetMap()
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return null;
         }
@@ -398,7 +398,7 @@ public class SettingValueRef
     }
     public SettingsListRef GetList()
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return null;
         }
@@ -407,7 +407,7 @@ public class SettingValueRef
     }
     public bool GetBool()
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return false;
         }
@@ -416,7 +416,7 @@ public class SettingValueRef
     }
     public long GetI64()
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return 0;
         }
@@ -425,7 +425,7 @@ public class SettingValueRef
     }
     public double GetF64()
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return 0;
         }
@@ -434,7 +434,7 @@ public class SettingValueRef
     }
     public string GetString()
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return "";
         }
@@ -445,17 +445,17 @@ public class SettingValueRef
 
 public class SettingValueRefMut : SettingValueRef
 {
-    internal SettingValueRefMut(IntPtr ptr) : base(ptr) { }
+    internal SettingValueRefMut(nint ptr) : base(ptr) { }
 }
 
 public class SettingValue : SettingValueRefMut, IDisposable
 {
     private void Drop()
     {
-        if (ptr != IntPtr.Zero)
+        if (ptr != 0)
         {
             ASRNative.SettingValue_drop(ptr);
-            ptr = IntPtr.Zero;
+            ptr = 0;
         }
     }
     ~SettingValue()
@@ -467,137 +467,137 @@ public class SettingValue : SettingValueRefMut, IDisposable
         Drop();
         GC.SuppressFinalize(this);
     }
-    public SettingValue(bool value) : base(IntPtr.Zero)
+    public SettingValue(bool value) : base(0)
     {
         ptr = ASRNative.SettingValue_new_bool(value ? (byte)1 : (byte)0);
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             throw new ArgumentException("Couldn't create the setting value.");
         }
     }
-    public SettingValue(long value) : base(IntPtr.Zero)
+    public SettingValue(long value) : base(0)
     {
         ptr = ASRNative.SettingValue_new_i64(value);
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             throw new ArgumentException("Couldn't create the setting value.");
         }
     }
-    public SettingValue(double value) : base(IntPtr.Zero)
+    public SettingValue(double value) : base(0)
     {
         ptr = ASRNative.SettingValue_new_f64(value);
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             throw new ArgumentException("Couldn't create the setting value.");
         }
     }
-    public SettingValue(string value) : base(IntPtr.Zero)
+    public SettingValue(string value) : base(0)
     {
         ptr = ASRNative.SettingValue_new_string(value);
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             throw new ArgumentException("Couldn't create the setting value.");
         }
     }
-    public SettingValue(SettingsMap value) : base(IntPtr.Zero)
+    public SettingValue(SettingsMap value) : base(0)
     {
-        IntPtr valuePtr = value.ptr;
-        if (valuePtr == IntPtr.Zero)
+        nint valuePtr = value.ptr;
+        if (valuePtr == 0)
         {
             throw new ArgumentException("Couldn't create the setting value.");
         }
 
-        value.ptr = IntPtr.Zero;
+        value.ptr = 0;
         ptr = ASRNative.SettingValue_new_map(valuePtr);
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             throw new ArgumentException("Couldn't create the setting value.");
         }
     }
-    public SettingValue(SettingsList value) : base(IntPtr.Zero)
+    public SettingValue(SettingsList value) : base(0)
     {
-        IntPtr valuePtr = value.ptr;
-        if (valuePtr == IntPtr.Zero)
+        nint valuePtr = value.ptr;
+        if (valuePtr == 0)
         {
             throw new ArgumentException("Couldn't create the setting value.");
         }
 
-        value.ptr = IntPtr.Zero;
+        value.ptr = 0;
         ptr = ASRNative.SettingValue_new_list(valuePtr);
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             throw new ArgumentException("Couldn't create the setting value.");
         }
     }
-    internal SettingValue(IntPtr ptr) : base(ptr) { }
+    internal SettingValue(nint ptr) : base(ptr) { }
 }
 
 public class WidgetsRef
 {
-    internal IntPtr ptr;
-    internal WidgetsRef(IntPtr ptr)
+    internal nint ptr;
+    internal WidgetsRef(nint ptr)
     {
         this.ptr = ptr;
     }
 
     public ulong GetLength()
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return 0;
         }
 
-        return (ulong)ASRNative.Widgets_len(ptr);
+        return ASRNative.Widgets_len(ptr);
     }
 
     public string GetKey(ulong index)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return "";
         }
 
-        return ASRNative.Widgets_get_key(ptr, (UIntPtr)index);
+        return ASRNative.Widgets_get_key(ptr, (nuint)index);
     }
 
     public string GetDescription(ulong index)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return "";
         }
 
-        return ASRNative.Widgets_get_description(ptr, (UIntPtr)index);
+        return ASRNative.Widgets_get_description(ptr, (nuint)index);
     }
 
     public string GetTooltip(ulong index)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return "";
         }
 
-        return ASRNative.Widgets_get_tooltip(ptr, (UIntPtr)index);
+        return ASRNative.Widgets_get_tooltip(ptr, (nuint)index);
     }
 
     public uint GetHeadingLevel(ulong index)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return 0;
         }
 
-        return ASRNative.Widgets_get_heading_level(ptr, (UIntPtr)index);
+        return ASRNative.Widgets_get_heading_level(ptr, (nuint)index);
     }
 
     public string GetType(ulong index)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return "";
         }
 
-        UIntPtr ty = ASRNative.Widgets_get_type(ptr, (UIntPtr)index);
+        nuint ty = ASRNative.Widgets_get_type(ptr, (nuint)index);
         return (ulong)ty switch
         {
             1 => "bool",
@@ -610,88 +610,88 @@ public class WidgetsRef
 
     public bool GetBool(ulong index, SettingsMapRef settingsMap)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return false;
         }
 
-        if (settingsMap.ptr == IntPtr.Zero)
+        if (settingsMap.ptr == 0)
         {
             return false;
         }
 
-        return ASRNative.Widgets_get_bool(ptr, (UIntPtr)index, settingsMap.ptr) != 0;
+        return ASRNative.Widgets_get_bool(ptr, (nuint)index, settingsMap.ptr) != 0;
     }
 
     public ulong GetChoiceCurrentIndex(ulong index, SettingsMapRef settingsMap)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return 0;
         }
 
-        if (settingsMap.ptr == IntPtr.Zero)
+        if (settingsMap.ptr == 0)
         {
             return 0;
         }
 
-        return (ulong)ASRNative.Widgets_get_choice_current_index(ptr, (UIntPtr)index, settingsMap.ptr);
+        return ASRNative.Widgets_get_choice_current_index(ptr, (nuint)index, settingsMap.ptr);
     }
 
     public ulong GetChoiceOptionsLength(ulong index)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return 0;
         }
 
-        return (ulong)ASRNative.Widgets_get_choice_options_len(ptr, (UIntPtr)index);
+        return ASRNative.Widgets_get_choice_options_len(ptr, (nuint)index);
     }
 
     public string GetChoiceOptionKey(ulong index, ulong optionIndex)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return "";
         }
 
-        return ASRNative.Widgets_get_choice_option_key(ptr, (UIntPtr)index, (UIntPtr)optionIndex);
+        return ASRNative.Widgets_get_choice_option_key(ptr, (nuint)index, (nuint)optionIndex);
     }
 
     public string GetChoiceOptionDescription(ulong index, ulong optionIndex)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return "";
         }
 
-        return ASRNative.Widgets_get_choice_option_description(ptr, (UIntPtr)index, (UIntPtr)optionIndex);
+        return ASRNative.Widgets_get_choice_option_description(ptr, (nuint)index, (nuint)optionIndex);
     }
 
     public string GetFileSelectFilter(ulong index)
     {
-        if (ptr == IntPtr.Zero)
+        if (ptr == 0)
         {
             return "";
         }
 
-        return ASRNative.Widgets_get_file_select_filter(ptr, (UIntPtr)index);
+        return ASRNative.Widgets_get_file_select_filter(ptr, (nuint)index);
     }
 }
 
 public class WidgetsRefMut : WidgetsRef
 {
-    internal WidgetsRefMut(IntPtr ptr) : base(ptr) { }
+    internal WidgetsRefMut(nint ptr) : base(ptr) { }
 }
 
 public class Widgets : WidgetsRefMut, IDisposable
 {
     private void Drop()
     {
-        if (ptr != IntPtr.Zero)
+        if (ptr != 0)
         {
             ASRNative.Widgets_drop(ptr);
-            ptr = IntPtr.Zero;
+            ptr = 0;
         }
     }
     ~Widgets()
@@ -703,19 +703,19 @@ public class Widgets : WidgetsRefMut, IDisposable
         Drop();
         GC.SuppressFinalize(this);
     }
-    internal Widgets(IntPtr ptr) : base(ptr) { }
+    internal Widgets(nint ptr) : base(ptr) { }
 }
 
 public delegate int StateDelegate();
 public delegate void SetGameTimeDelegate(long gameTime);
-public delegate void LogDelegate(IntPtr messagePtr, UIntPtr messageLen);
+public delegate void LogDelegate(nint messagePtr, nuint messageLen);
 
 public static class ASRNative
 {
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern IntPtr Runtime_new(
+    public static extern nint Runtime_new(
         ASRString path,
-        IntPtr settings_map,
+        nint settings_map,
         StateDelegate state,
         Action start,
         Action split,
@@ -728,108 +728,108 @@ public static class ASRNative
         LogDelegate log
     );
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern void Runtime_drop(IntPtr self);
+    public static extern void Runtime_drop(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern bool Runtime_step(IntPtr self);
+    public static extern bool Runtime_step(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern ulong Runtime_tick_rate(IntPtr self);
+    public static extern ulong Runtime_tick_rate(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern IntPtr Runtime_get_settings_widgets(IntPtr self);
+    public static extern nint Runtime_get_settings_widgets(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern void Runtime_settings_map_set_bool(IntPtr self, ASRString key, byte value);
+    public static extern void Runtime_settings_map_set_bool(nint self, ASRString key, byte value);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern void Runtime_settings_map_set_string(IntPtr self, ASRString key, ASRString value);
+    public static extern void Runtime_settings_map_set_string(nint self, ASRString key, ASRString value);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern IntPtr Runtime_get_settings_map(IntPtr self);
+    public static extern nint Runtime_get_settings_map(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern void Runtime_set_settings_map(IntPtr self, IntPtr settings_map);
+    public static extern void Runtime_set_settings_map(nint self, nint settings_map);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern byte Runtime_are_settings_changed(IntPtr self, IntPtr previous_settings_map, IntPtr previous_widgets);
+    public static extern byte Runtime_are_settings_changed(nint self, nint previous_settings_map, nint previous_widgets);
 
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern IntPtr SettingsMap_new();
+    public static extern nint SettingsMap_new();
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern void SettingsMap_drop(IntPtr self);
+    public static extern void SettingsMap_drop(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern void SettingsMap_insert(IntPtr self, ASRString key, IntPtr value);
+    public static extern void SettingsMap_insert(nint self, ASRString key, nint value);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern UIntPtr SettingsMap_len(IntPtr self);
+    public static extern nuint SettingsMap_len(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern ASRString SettingsMap_get_key(IntPtr self, UIntPtr index);
+    public static extern ASRString SettingsMap_get_key(nint self, nuint index);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern IntPtr SettingsMap_get_value(IntPtr self, UIntPtr index);
+    public static extern nint SettingsMap_get_value(nint self, nuint index);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern IntPtr SettingsMap_get_value_by_key(IntPtr self, ASRString key);
+    public static extern nint SettingsMap_get_value_by_key(nint self, ASRString key);
 
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern IntPtr SettingsList_new();
+    public static extern nint SettingsList_new();
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern void SettingsList_drop(IntPtr self);
+    public static extern void SettingsList_drop(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern void SettingsList_push(IntPtr self, IntPtr value);
+    public static extern void SettingsList_push(nint self, nint value);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern UIntPtr SettingsList_len(IntPtr self);
+    public static extern nuint SettingsList_len(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern IntPtr SettingsList_get(IntPtr self, UIntPtr index);
+    public static extern nint SettingsList_get(nint self, nuint index);
 
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern IntPtr SettingValue_new_map(IntPtr value);
+    public static extern nint SettingValue_new_map(nint value);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern IntPtr SettingValue_new_list(IntPtr value);
+    public static extern nint SettingValue_new_list(nint value);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern IntPtr SettingValue_new_bool(byte value);
+    public static extern nint SettingValue_new_bool(byte value);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern IntPtr SettingValue_new_i64(long value);
+    public static extern nint SettingValue_new_i64(long value);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern IntPtr SettingValue_new_f64(double value);
+    public static extern nint SettingValue_new_f64(double value);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern IntPtr SettingValue_new_string(ASRString value);
+    public static extern nint SettingValue_new_string(ASRString value);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern void SettingValue_drop(IntPtr self);
+    public static extern void SettingValue_drop(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern UIntPtr SettingValue_get_type(IntPtr self);
+    public static extern nuint SettingValue_get_type(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern IntPtr SettingValue_get_map(IntPtr self);
+    public static extern nint SettingValue_get_map(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern IntPtr SettingValue_get_list(IntPtr self);
+    public static extern nint SettingValue_get_list(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern byte SettingValue_get_bool(IntPtr self);
+    public static extern byte SettingValue_get_bool(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern long SettingValue_get_i64(IntPtr self);
+    public static extern long SettingValue_get_i64(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern double SettingValue_get_f64(IntPtr self);
+    public static extern double SettingValue_get_f64(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern ASRString SettingValue_get_string(IntPtr self);
+    public static extern ASRString SettingValue_get_string(nint self);
 
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern void Widgets_drop(IntPtr self);
+    public static extern void Widgets_drop(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern UIntPtr Widgets_len(IntPtr self);
+    public static extern nuint Widgets_len(nint self);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern ASRString Widgets_get_key(IntPtr self, UIntPtr index);
+    public static extern ASRString Widgets_get_key(nint self, nuint index);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern ASRString Widgets_get_description(IntPtr self, UIntPtr index);
+    public static extern ASRString Widgets_get_description(nint self, nuint index);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern ASRString Widgets_get_tooltip(IntPtr self, UIntPtr index);
+    public static extern ASRString Widgets_get_tooltip(nint self, nuint index);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern uint Widgets_get_heading_level(IntPtr self, UIntPtr index);
+    public static extern uint Widgets_get_heading_level(nint self, nuint index);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern UIntPtr Widgets_get_type(IntPtr self, UIntPtr index);
+    public static extern nuint Widgets_get_type(nint self, nuint index);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern byte Widgets_get_bool(IntPtr self, UIntPtr index, IntPtr settings_map);
+    public static extern byte Widgets_get_bool(nint self, nuint index, nint settings_map);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern UIntPtr Widgets_get_choice_current_index(IntPtr self, UIntPtr index, IntPtr settings_map);
+    public static extern nuint Widgets_get_choice_current_index(nint self, nuint index, nint settings_map);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern UIntPtr Widgets_get_choice_options_len(IntPtr self, UIntPtr index);
+    public static extern nuint Widgets_get_choice_options_len(nint self, nuint index);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern ASRString Widgets_get_choice_option_key(IntPtr self, UIntPtr index, UIntPtr option_index);
+    public static extern ASRString Widgets_get_choice_option_key(nint self, nuint index, nuint option_index);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern ASRString Widgets_get_choice_option_description(IntPtr self, UIntPtr index, UIntPtr option_index);
+    public static extern ASRString Widgets_get_choice_option_description(nint self, nuint index, nuint option_index);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern ASRString Widgets_get_file_select_filter(IntPtr self, UIntPtr index);
+    public static extern ASRString Widgets_get_file_select_filter(nint self, nuint index);
 
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern UIntPtr get_buf_len();
+    public static extern nuint get_buf_len();
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
     public static extern ASRString path_to_wasi(ASRString original_path);
     [DllImport("asr_capi", CallingConvention = CallingConvention.Cdecl)]
@@ -840,7 +840,7 @@ public class ASRString : SafeHandle
 {
     private bool needToFree;
 
-    public ASRString() : base(IntPtr.Zero, false) { }
+    public ASRString() : base((nint)0, false) { }
 
     public override bool IsInvalid => false;
 
@@ -851,7 +851,7 @@ public class ASRString : SafeHandle
         int len = Encoding.UTF8.GetByteCount(managedString);
         byte[] buffer = new byte[len + 1];
         Encoding.UTF8.GetBytes(managedString, 0, managedString.Length, buffer, 0);
-        IntPtr nativeUtf8 = Marshal.AllocHGlobal(buffer.Length);
+        nint nativeUtf8 = Marshal.AllocHGlobal(buffer.Length);
         Marshal.Copy(buffer, 0, nativeUtf8, buffer.Length);
 
         asrString.SetHandle(nativeUtf8);
@@ -859,9 +859,9 @@ public class ASRString : SafeHandle
         return asrString;
     }
 
-    public static string FromPtrLen(IntPtr ptr, UIntPtr len)
+    public static string FromPtrLen(nint ptr, nuint len)
     {
-        if (ptr == IntPtr.Zero || (ulong)len > int.MaxValue)
+        if (ptr == 0 || (ulong)len > int.MaxValue)
         {
             return null;
         }

--- a/src/LiveSplit.AutoSplittingRuntime/ASR.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASR.cs
@@ -148,7 +148,7 @@ public class Runtime : RuntimeRefMut, IDisposable
             return;
         }
 
-        var settingsMapPtr = settingsMap.ptr;
+        IntPtr settingsMapPtr = settingsMap.ptr;
         if (settingsMapPtr == IntPtr.Zero)
         {
             return;
@@ -220,7 +220,7 @@ public class SettingsMapRef
             return null;
         }
 
-        var valuePtr = ASRNative.SettingsMap_get_value_by_key(ptr, key);
+        IntPtr valuePtr = ASRNative.SettingsMap_get_value_by_key(ptr, key);
         if (valuePtr != IntPtr.Zero)
         {
             return new SettingValueRef(valuePtr);
@@ -242,7 +242,7 @@ public class SettingsMapRefMut : SettingsMapRef
             return;
         }
 
-        var valuePtr = value.ptr;
+        IntPtr valuePtr = value.ptr;
         if (valuePtr == IntPtr.Zero)
         {
             return;
@@ -320,7 +320,7 @@ public class SettingsListRefMut : SettingsListRef
             return;
         }
 
-        var valuePtr = value.ptr;
+        IntPtr valuePtr = value.ptr;
         if (valuePtr == IntPtr.Zero)
         {
             return;
@@ -375,7 +375,7 @@ public class SettingValueRef
             return "";
         }
 
-        var ty = ASRNative.SettingValue_get_type(ptr);
+        UIntPtr ty = ASRNative.SettingValue_get_type(ptr);
         switch ((ulong)ty)
         {
             case 1: return "map";
@@ -501,7 +501,7 @@ public class SettingValue : SettingValueRefMut, IDisposable
     }
     public SettingValue(SettingsMap value) : base(IntPtr.Zero)
     {
-        var valuePtr = value.ptr;
+        IntPtr valuePtr = value.ptr;
         if (valuePtr == IntPtr.Zero)
         {
             throw new ArgumentException("Couldn't create the setting value.");
@@ -516,7 +516,7 @@ public class SettingValue : SettingValueRefMut, IDisposable
     }
     public SettingValue(SettingsList value) : base(IntPtr.Zero)
     {
-        var valuePtr = value.ptr;
+        IntPtr valuePtr = value.ptr;
         if (valuePtr == IntPtr.Zero)
         {
             throw new ArgumentException("Couldn't create the setting value.");
@@ -597,7 +597,7 @@ public class WidgetsRef
             return "";
         }
 
-        var ty = ASRNative.Widgets_get_type(ptr, (UIntPtr)index);
+        UIntPtr ty = ASRNative.Widgets_get_type(ptr, (UIntPtr)index);
         switch ((ulong)ty)
         {
             case 1: return "bool";
@@ -846,7 +846,7 @@ public class ASRString : SafeHandle
 
     public static implicit operator ASRString(string managedString)
     {
-        ASRString asrString = new ASRString();
+        var asrString = new ASRString();
 
         int len = Encoding.UTF8.GetByteCount(managedString);
         byte[] buffer = new byte[len + 1];

--- a/src/LiveSplit.AutoSplittingRuntime/ASRComponent.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASRComponent.cs
@@ -114,7 +114,9 @@ public class ASRComponent : LogicComponent
                     double tickRate = settings.runtime.TickRate().TotalMilliseconds;
 
                     if (updateTimer != null && tickRate != updateTimer.Interval)
+                    {
                         updateTimer.Interval = tickRate;
+                    }
                 }
             });
         }
@@ -127,8 +129,12 @@ public class ASRComponent : LogicComponent
     private void InvokeIfNeeded(Action x)
     {
         if (parentForm != null && parentForm.InvokeRequired)
+        {
             parentForm.Invoke(x);
+        }
         else
+        {
             x();
+        }
     }
 }

--- a/src/LiveSplit.AutoSplittingRuntime/ASRComponent.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASRComponent.cs
@@ -1,138 +1,134 @@
-﻿using LiveSplit.Model;
-using LiveSplit.Options;
-using LiveSplit.UI;
-using LiveSplit.UI.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System;
 using System.Windows.Forms;
 using System.Xml;
+
+using LiveSplit.Model;
+using LiveSplit.UI;
+using LiveSplit.UI.Components;
+
 using Timer = System.Timers.Timer;
 
-namespace LiveSplit.AutoSplittingRuntime
+namespace LiveSplit.AutoSplittingRuntime;
+
+public class ASRComponent : LogicComponent
 {
-    public class ASRComponent : LogicComponent
+    private readonly TimerModel model;
+    private readonly ComponentSettings settings;
+    private readonly Form parentForm;
+    private Timer updateTimer;
+
+    static ASRComponent()
     {
-        private readonly TimerModel model;
-        private readonly ComponentSettings settings;
-        private readonly Form parentForm;
-        private Timer updateTimer;
-
-        static ASRComponent()
+        try
         {
-            try
+            ASRLoader.LoadASR();
+        }
+        catch { }
+    }
+
+    public ASRComponent(LiveSplitState state)
+    {
+        parentForm = state.Form;
+
+        model = new TimerModel() { CurrentState = state };
+
+        settings = new ComponentSettings(model);
+
+        InitializeUpdateTimer();
+    }
+
+    public ASRComponent(LiveSplitState state, string scriptPath)
+    {
+        model = new TimerModel() { CurrentState = state };
+
+        settings = new ComponentSettings(model, scriptPath);
+
+        InitializeUpdateTimer();
+    }
+
+    private void InitializeUpdateTimer()
+    {
+        updateTimer = new Timer() { Interval = 15 };
+        updateTimer.Elapsed += UpdateTimerElapsed;
+        updateTimer.Start();
+    }
+
+    public override string ComponentName => "Auto Splitting Runtime";
+
+    public override void Dispose()
+    {
+        updateTimer.Elapsed -= UpdateTimerElapsed;
+        updateTimer.Dispose();
+        updateTimer = null;
+        settings.runtime?.Dispose();
+    }
+
+    public override XmlNode GetSettings(XmlDocument document)
+    {
+        return settings.GetSettings(document);
+    }
+
+    public override Control GetSettingsControl(LayoutMode mode)
+    {
+        return settings;
+    }
+
+    public override void SetSettings(XmlNode settings)
+    {
+        this.settings.SetSettings(settings);
+    }
+
+    public override void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode) { }
+
+    public void UpdateTimerElapsed(object sender, EventArgs e)
+    {
+        // This refresh timer behavior is similar to the ASL refresh timer
+
+        // Disable timer, to wait for execution of this iteration to
+        // finish. This can be useful if blocking operations like
+        // showing a message window are used.
+        updateTimer?.Stop();
+
+        try
+        {
+            InvokeIfNeeded(() =>
             {
-                ASRLoader.LoadASR();
-            }
-            catch { }
-        }
-
-        public ASRComponent(LiveSplitState state)
-        {
-            parentForm = state.Form;
-
-            model = new TimerModel() { CurrentState = state };
-
-            settings = new ComponentSettings(model);
-
-            InitializeUpdateTimer();
-        }
-
-        public ASRComponent(LiveSplitState state, string scriptPath)
-        {
-            model = new TimerModel() { CurrentState = state };
-
-            settings = new ComponentSettings(model, scriptPath);
-
-            InitializeUpdateTimer();
-        }
-
-        private void InitializeUpdateTimer()
-        {
-            updateTimer = new Timer() { Interval = 15 };
-            updateTimer.Elapsed += UpdateTimerElapsed;
-            updateTimer.Start();
-        }
-
-        public override string ComponentName => "Auto Splitting Runtime";
-
-        public override void Dispose()
-        {
-            updateTimer.Elapsed -= UpdateTimerElapsed;
-            updateTimer.Dispose();
-            updateTimer = null;
-            settings.runtime?.Dispose();
-        }
-
-        public override XmlNode GetSettings(XmlDocument document)
-        {
-            return settings.GetSettings(document);
-        }
-
-        public override Control GetSettingsControl(LayoutMode mode)
-        {
-            return settings;
-        }
-
-        public override void SetSettings(XmlNode settings)
-        {
-            this.settings.SetSettings(settings);
-        }
-
-        public override void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode) { }
-
-        public void UpdateTimerElapsed(object sender, EventArgs e)
-        {
-            // This refresh timer behavior is similar to the ASL refresh timer
-
-            // Disable timer, to wait for execution of this iteration to
-            // finish. This can be useful if blocking operations like
-            // showing a message window are used.
-            updateTimer?.Stop();
-
-            try
-            {
-                InvokeIfNeeded(() =>
+                if (settings.runtime != null)
                 {
-                    if (settings.runtime != null)
+                    settings.runtime.Step();
+
+                    try
                     {
-                        settings.runtime.Step();
-
-                        try
+                        if (
+                            settings.previousMap == null
+                            || settings.previousWidgets == null
+                            || settings.runtime.AreSettingsChanged(settings.previousMap, settings.previousWidgets)
+                        )
                         {
-                            if (
-                                settings.previousMap == null
-                                || settings.previousWidgets == null
-                                || settings.runtime.AreSettingsChanged(settings.previousMap, settings.previousWidgets)
-                            )
-                            {
-                                settings.BuildTree();
-                            }
+                            settings.BuildTree();
                         }
-                        catch { }
-
-                        // Poll the tick rate and modify the update interval if it has been changed
-                        double tickRate = settings.runtime.TickRate().TotalMilliseconds;
-
-                        if (updateTimer != null && tickRate != updateTimer.Interval)
-                            updateTimer.Interval = tickRate;
                     }
-                });
-            }
-            finally
-            {
-                updateTimer?.Start();
-            }
-        }
+                    catch { }
 
-        private void InvokeIfNeeded(Action x)
-        {
-            if (parentForm != null && parentForm.InvokeRequired)
-                parentForm.Invoke(x);
-            else
-                x();
+                    // Poll the tick rate and modify the update interval if it has been changed
+                    double tickRate = settings.runtime.TickRate().TotalMilliseconds;
+
+                    if (updateTimer != null && tickRate != updateTimer.Interval)
+                        updateTimer.Interval = tickRate;
+                }
+            });
         }
+        finally
+        {
+            updateTimer?.Start();
+        }
+    }
+
+    private void InvokeIfNeeded(Action x)
+    {
+        if (parentForm != null && parentForm.InvokeRequired)
+            parentForm.Invoke(x);
+        else
+            x();
     }
 }

--- a/src/LiveSplit.AutoSplittingRuntime/ASRFactory.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASRFactory.cs
@@ -1,28 +1,24 @@
-﻿using LiveSplit.AutoSplittingRuntime;
+﻿using System;
+
+using LiveSplit.AutoSplittingRuntime;
 using LiveSplit.Model;
 using LiveSplit.UI.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 [assembly: ComponentFactory(typeof(ASRFactory))]
 
-namespace LiveSplit.AutoSplittingRuntime
+namespace LiveSplit.AutoSplittingRuntime;
+
+public class ASRFactory : IComponentFactory
 {
-    public class ASRFactory : IComponentFactory
-    {
-        public string ComponentName => "Auto Splitting Runtime";
-        public string Description => "Allows auto splitters provided as WebAssembly modules to define the splitting behaviour.";
-        public ComponentCategory Category => ComponentCategory.Control;
-        public Version Version => Version.Parse("0.0.9");
+    public string ComponentName => "Auto Splitting Runtime";
+    public string Description => "Allows auto splitters provided as WebAssembly modules to define the splitting behaviour.";
+    public ComponentCategory Category => ComponentCategory.Control;
+    public Version Version => Version.Parse("0.0.9");
 
-        public string UpdateName => ComponentName;
-        public string UpdateURL => "http://livesplit.org/update/";
-        public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.AutoSplittingRuntime.xml";
+    public string UpdateName => ComponentName;
+    public string UpdateURL => "http://livesplit.org/update/";
+    public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.AutoSplittingRuntime.xml";
 
-        public IComponent Create(LiveSplitState state) => new ASRComponent(state);
-        public IComponent Create(LiveSplitState state, string script) => new ASRComponent(state, script);
-    }
+    public IComponent Create(LiveSplitState state) => new ASRComponent(state);
+    public IComponent Create(LiveSplitState state, string script) => new ASRComponent(state, script);
 }

--- a/src/LiveSplit.AutoSplittingRuntime/ASRFactory.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASRFactory.cs
@@ -19,6 +19,13 @@ public class ASRFactory : IComponentFactory
     public string UpdateURL => "http://livesplit.org/update/";
     public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.AutoSplittingRuntime.xml";
 
-    public IComponent Create(LiveSplitState state) => new ASRComponent(state);
-    public IComponent Create(LiveSplitState state, string script) => new ASRComponent(state, script);
+    public IComponent Create(LiveSplitState state)
+    {
+        return new ASRComponent(state);
+    }
+
+    public IComponent Create(LiveSplitState state, string script)
+    {
+        return new ASRComponent(state, script);
+    }
 }

--- a/src/LiveSplit.AutoSplittingRuntime/ASRLoader.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASRLoader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace LiveSplit.AutoSplittingRuntime;
@@ -41,7 +42,7 @@ public class ASRLoader
 
         string path;
 
-        if (IntPtr.Size == 8)
+        if (Unsafe.SizeOf<nint>() == 8)
         {
             path = @"Components\x64\asr_capi.dll";
         }

--- a/src/LiveSplit.AutoSplittingRuntime/ASRLoader.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASRLoader.cs
@@ -1,58 +1,57 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace LiveSplit.AutoSplittingRuntime
+namespace LiveSplit.AutoSplittingRuntime;
+
+public class ASRLoader
 {
-    public class ASRLoader
+    [DllImport("kernel32")]
+    private unsafe static extern void* LoadLibrary(string dllname);
+
+    [DllImport("kernel32")]
+    private unsafe static extern void FreeLibrary(void* handle);
+
+    private sealed unsafe class LibraryUnloader
     {
-        [DllImport("kernel32")]
-        private unsafe static extern void* LoadLibrary(string dllname);
-
-        [DllImport("kernel32")]
-        private unsafe static extern void FreeLibrary(void* handle);
-
-        private sealed unsafe class LibraryUnloader
+        internal LibraryUnloader(void* handle)
         {
-            internal LibraryUnloader(void* handle)
-            {
-                this.handle = handle;
-            }
-
-            ~LibraryUnloader()
-            {
-                if (handle != null)
-                    FreeLibrary(handle);
-            }
-
-            private void* handle;
-
+            this.handle = handle;
         }
 
-        private static LibraryUnloader unloader;
-
-        public static void LoadASR()
+        ~LibraryUnloader()
         {
-            if (unloader != null)
-            {
-                return;
-            }
+            if (handle != null)
+                FreeLibrary(handle);
+        }
 
-            string path;
+        private void* handle;
 
-            if (IntPtr.Size == 8)
-                path = @"Components\x64\asr_capi.dll";
-            else
-                path = @"Components\x86\asr_capi.dll";
+    }
 
-            unsafe
-            {
-                void* handle = LoadLibrary(path);
+    private static LibraryUnloader unloader;
 
-                if (handle == null)
-                    throw new DllNotFoundException("Unable to load the native ASR library: " + path);
+    public static void LoadASR()
+    {
+        if (unloader != null)
+        {
+            return;
+        }
 
-                unloader = new LibraryUnloader(handle);
-            }
+        string path;
+
+        if (IntPtr.Size == 8)
+            path = @"Components\x64\asr_capi.dll";
+        else
+            path = @"Components\x86\asr_capi.dll";
+
+        unsafe
+        {
+            void* handle = LoadLibrary(path);
+
+            if (handle == null)
+                throw new DllNotFoundException("Unable to load the native ASR library: " + path);
+
+            unloader = new LibraryUnloader(handle);
         }
     }
 }

--- a/src/LiveSplit.AutoSplittingRuntime/ASRLoader.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASRLoader.cs
@@ -24,7 +24,7 @@ public class ASRLoader
                 FreeLibrary(handle);
         }
 
-        private void* handle;
+        private readonly void* handle;
 
     }
 

--- a/src/LiveSplit.AutoSplittingRuntime/ASRLoader.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASRLoader.cs
@@ -21,7 +21,9 @@ public class ASRLoader
         ~LibraryUnloader()
         {
             if (handle != null)
+            {
                 FreeLibrary(handle);
+            }
         }
 
         private readonly void* handle;
@@ -40,16 +42,22 @@ public class ASRLoader
         string path;
 
         if (IntPtr.Size == 8)
+        {
             path = @"Components\x64\asr_capi.dll";
+        }
         else
+        {
             path = @"Components\x86\asr_capi.dll";
+        }
 
         unsafe
         {
             void* handle = LoadLibrary(path);
 
             if (handle == null)
+            {
                 throw new DllNotFoundException("Unable to load the native ASR library: " + path);
+            }
 
             unloader = new LibraryUnloader(handle);
         }

--- a/src/LiveSplit.AutoSplittingRuntime/ASRSettings.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASRSettings.cs
@@ -52,10 +52,7 @@ public class ASRSettings
 
     public void AddSetting(string name, bool default_value, string description, string parent)
     {
-        if (description == null)
-        {
-            description = name;
-        }
+        description ??= name;
 
         if (parent != null && !Settings.ContainsKey(parent))
         {
@@ -140,10 +137,7 @@ public class ASRSettingsBuilder
 
     public void Add(string id, bool default_value = true, string description = null, string parent = null)
     {
-        if (parent == null)
-        {
-            parent = CurrentDefaultParent;
-        }
+        parent ??= CurrentDefaultParent;
 
         _s.AddSetting(id, default_value, description, parent);
     }

--- a/src/LiveSplit.AutoSplittingRuntime/ASRSettings.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASRSettings.cs
@@ -116,7 +116,7 @@ public class ASRSettings
 public class ASRSettingsBuilder
 {
     public string CurrentDefaultParent { get; set; }
-    private ASRSettings _s;
+    private readonly ASRSettings _s;
 
     public ASRSettingsBuilder(ASRSettings s)
     {
@@ -145,7 +145,7 @@ public class ASRSettingsBuilder
 /// </summary>
 public class ASRSettingsReader
 {
-    private ASRSettings _s;
+    private readonly ASRSettings _s;
 
     public ASRSettingsReader(ASRSettings s)
     {

--- a/src/LiveSplit.AutoSplittingRuntime/ASRSettings.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASRSettings.cs
@@ -43,9 +43,9 @@ public class ASRSettings
 
     public ASRSettings()
     {
-        Settings = new Dictionary<string, ASRSetting>();
-        OrderedSettings = new List<ASRSetting>();
-        BasicSettings = new Dictionary<string, ASRSetting>();
+        Settings = [];
+        OrderedSettings = [];
+        BasicSettings = [];
         Builder = new ASRSettingsBuilder(this);
         Reader = new ASRSettingsReader(this);
     }

--- a/src/LiveSplit.AutoSplittingRuntime/ASRSettings.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASRSettings.cs
@@ -53,11 +53,19 @@ public class ASRSettings
     public void AddSetting(string name, bool default_value, string description, string parent)
     {
         if (description == null)
+        {
             description = name;
+        }
+
         if (parent != null && !Settings.ContainsKey(parent))
+        {
             throw new ArgumentException($"Parent for setting '{name}' is not a setting: {parent}");
+        }
+
         if (Settings.ContainsKey(name))
+        {
             throw new ArgumentException($"Setting '{name}' was already added");
+        }
 
         var setting = new ASRSetting(name, default_value, description, parent);
         Settings.Add(name, setting);
@@ -69,7 +77,9 @@ public class ASRSettings
         // Don't cause error if setting doesn't exist, but still inform script
         // author since that usually shouldn't happen.
         if (Settings.ContainsKey(name))
+        {
             return GetSettingValueRecursive(Settings[name]);
+        }
 
         Log.Info("[ASR] Custom Setting Key doesn't exist: " + name);
 
@@ -84,7 +94,9 @@ public class ASRSettings
     public bool GetBasicSettingValue(string name)
     {
         if (BasicSettings.ContainsKey(name))
+        {
             return BasicSettings[name].Value;
+        }
 
         return false;
     }
@@ -94,17 +106,20 @@ public class ASRSettings
         return BasicSettings.ContainsKey(name);
     }
 
-
     /// <summary>
     /// Returns true only if this setting and all it's parent settings are true.
     /// </summary>
     private bool GetSettingValueRecursive(ASRSetting setting)
     {
         if (!setting.Value)
+        {
             return false;
+        }
 
         if (setting.Parent == null)
+        {
             return setting.Value;
+        }
 
         return GetSettingValueRecursive(Settings[setting.Parent]);
     }
@@ -126,7 +141,9 @@ public class ASRSettingsBuilder
     public void Add(string id, bool default_value = true, string description = null, string parent = null)
     {
         if (parent == null)
+        {
             parent = CurrentDefaultParent;
+        }
 
         _s.AddSetting(id, default_value, description, parent);
     }
@@ -134,7 +151,9 @@ public class ASRSettingsBuilder
     public void SetToolTip(string id, string text)
     {
         if (!_s.Settings.ContainsKey(id))
+        {
             throw new ArgumentException($"Can't set tooltip, '{id}' is not a setting");
+        }
 
         _s.Settings[id].ToolTip = text;
     }

--- a/src/LiveSplit.AutoSplittingRuntime/ASRSettings.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASRSettings.cs
@@ -152,28 +152,16 @@ public class ASRSettingsReader
         _s = s;
     }
 
-    public dynamic this[string id]
-    {
-        get { return _s.GetSettingValue(id); }
-    }
+    public dynamic this[string id] => _s.GetSettingValue(id);
 
     public bool ContainsKey(string key)
     {
         return _s.Settings.ContainsKey(key);
     }
 
-    public bool StartEnabled
-    {
-        get { return _s.GetBasicSettingValue("start"); }
-    }
+    public bool StartEnabled => _s.GetBasicSettingValue("start");
 
-    public bool ResetEnabled
-    {
-        get { return _s.GetBasicSettingValue("reset"); }
-    }
+    public bool ResetEnabled => _s.GetBasicSettingValue("reset");
 
-    public bool SplitEnabled
-    {
-        get { return _s.GetBasicSettingValue("split"); }
-    }
+    public bool SplitEnabled => _s.GetBasicSettingValue("split");
 }

--- a/src/LiveSplit.AutoSplittingRuntime/ASRSettings.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASRSettings.cs
@@ -1,182 +1,179 @@
-﻿using LiveSplit.Options;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace LiveSplit.AutoSplittingRuntime
+using LiveSplit.Options;
+
+namespace LiveSplit.AutoSplittingRuntime;
+
+public class ASRSetting
 {
-    public class ASRSetting
+    public string Id { get; }
+    public string Label { get; }
+    public bool Value { get; set; }
+    public bool DefaultValue { get; }
+    public string Parent { get; }
+    public string ToolTip { get; set; }
+
+    public ASRSetting(string id, bool default_value, string label, string parent)
     {
-        public string Id { get; }
-        public string Label { get; }
-        public bool Value { get; set; }
-        public bool DefaultValue { get; }
-        public string Parent { get; }
-        public string ToolTip { get; set; }
-
-        public ASRSetting(string id, bool default_value, string label, string parent)
-        {
-            Id = id;
-            Value = default_value;
-            DefaultValue = default_value;
-            Label = label;
-            Parent = parent;
-        }
-
-        public override string ToString()
-        {
-            return Label;
-        }
+        Id = id;
+        Value = default_value;
+        DefaultValue = default_value;
+        Label = label;
+        Parent = parent;
     }
 
-    public class ASRSettings
+    public override string ToString()
     {
-        // Dict for easy access per key
-        public Dictionary<string, ASRSetting> Settings { get; set; }
-        // List for preserved insertion order (Dict provides that as well, but not guaranteed)
-        public List<ASRSetting> OrderedSettings { get; }
-
-        public Dictionary<string, ASRSetting> BasicSettings { get; }
-
-        public ASRSettingsBuilder Builder;
-        public ASRSettingsReader Reader;
-
-        public ASRSettings()
-        {
-            Settings = new Dictionary<string, ASRSetting>();
-            OrderedSettings = new List<ASRSetting>();
-            BasicSettings = new Dictionary<string, ASRSetting>();
-            Builder = new ASRSettingsBuilder(this);
-            Reader = new ASRSettingsReader(this);
-        }
-
-        public void AddSetting(string name, bool default_value, string description, string parent)
-        {
-            if (description == null)
-                description = name;
-            if (parent != null && !Settings.ContainsKey(parent))
-                throw new ArgumentException($"Parent for setting '{name}' is not a setting: {parent}");
-            if (Settings.ContainsKey(name))
-                throw new ArgumentException($"Setting '{name}' was already added");
-
-            var setting = new ASRSetting(name, default_value, description, parent);
-            Settings.Add(name, setting);
-            OrderedSettings.Add(setting);
-        }
-
-        public bool GetSettingValue(string name)
-        {
-            // Don't cause error if setting doesn't exist, but still inform script
-            // author since that usually shouldn't happen.
-            if (Settings.ContainsKey(name))
-                return GetSettingValueRecursive(Settings[name]);
-
-            Log.Info("[ASR] Custom Setting Key doesn't exist: " + name);
-
-            return false;
-        }
-
-        public void AddBasicSetting(string name)
-        {
-            BasicSettings.Add(name, new ASRSetting(name, true, "", null));
-        }
-
-        public bool GetBasicSettingValue(string name)
-        {
-            if (BasicSettings.ContainsKey(name))
-                return BasicSettings[name].Value;
-
-            return false;
-        }
-
-        public bool IsBasicSettingPresent(string name)
-        {
-            return BasicSettings.ContainsKey(name);
-        }
-
-
-        /// <summary>
-        /// Returns true only if this setting and all it's parent settings are true.
-        /// </summary>
-        private bool GetSettingValueRecursive(ASRSetting setting)
-        {
-            if (!setting.Value)
-                return false;
-
-            if (setting.Parent == null)
-                return setting.Value;
-
-            return GetSettingValueRecursive(Settings[setting.Parent]);
-        }
+        return Label;
     }
+}
+
+public class ASRSettings
+{
+    // Dict for easy access per key
+    public Dictionary<string, ASRSetting> Settings { get; set; }
+    // List for preserved insertion order (Dict provides that as well, but not guaranteed)
+    public List<ASRSetting> OrderedSettings { get; }
+
+    public Dictionary<string, ASRSetting> BasicSettings { get; }
+
+    public ASRSettingsBuilder Builder;
+    public ASRSettingsReader Reader;
+
+    public ASRSettings()
+    {
+        Settings = new Dictionary<string, ASRSetting>();
+        OrderedSettings = new List<ASRSetting>();
+        BasicSettings = new Dictionary<string, ASRSetting>();
+        Builder = new ASRSettingsBuilder(this);
+        Reader = new ASRSettingsReader(this);
+    }
+
+    public void AddSetting(string name, bool default_value, string description, string parent)
+    {
+        if (description == null)
+            description = name;
+        if (parent != null && !Settings.ContainsKey(parent))
+            throw new ArgumentException($"Parent for setting '{name}' is not a setting: {parent}");
+        if (Settings.ContainsKey(name))
+            throw new ArgumentException($"Setting '{name}' was already added");
+
+        var setting = new ASRSetting(name, default_value, description, parent);
+        Settings.Add(name, setting);
+        OrderedSettings.Add(setting);
+    }
+
+    public bool GetSettingValue(string name)
+    {
+        // Don't cause error if setting doesn't exist, but still inform script
+        // author since that usually shouldn't happen.
+        if (Settings.ContainsKey(name))
+            return GetSettingValueRecursive(Settings[name]);
+
+        Log.Info("[ASR] Custom Setting Key doesn't exist: " + name);
+
+        return false;
+    }
+
+    public void AddBasicSetting(string name)
+    {
+        BasicSettings.Add(name, new ASRSetting(name, true, "", null));
+    }
+
+    public bool GetBasicSettingValue(string name)
+    {
+        if (BasicSettings.ContainsKey(name))
+            return BasicSettings[name].Value;
+
+        return false;
+    }
+
+    public bool IsBasicSettingPresent(string name)
+    {
+        return BasicSettings.ContainsKey(name);
+    }
+
 
     /// <summary>
-    /// Interface for adding settings via the ASR Script.
+    /// Returns true only if this setting and all it's parent settings are true.
     /// </summary>
-    public class ASRSettingsBuilder
+    private bool GetSettingValueRecursive(ASRSetting setting)
     {
-        public string CurrentDefaultParent { get; set; }
-        private ASRSettings _s;
+        if (!setting.Value)
+            return false;
 
-        public ASRSettingsBuilder(ASRSettings s)
-        {
-            _s = s;
-        }
+        if (setting.Parent == null)
+            return setting.Value;
 
-        public void Add(string id, bool default_value = true, string description = null, string parent = null)
-        {
-            if (parent == null)
-                parent = CurrentDefaultParent;
+        return GetSettingValueRecursive(Settings[setting.Parent]);
+    }
+}
 
-            _s.AddSetting(id, default_value, description, parent);
-        }
+/// <summary>
+/// Interface for adding settings via the ASR Script.
+/// </summary>
+public class ASRSettingsBuilder
+{
+    public string CurrentDefaultParent { get; set; }
+    private ASRSettings _s;
 
-        public void SetToolTip(string id, string text)
-        {
-            if (!_s.Settings.ContainsKey(id))
-                throw new ArgumentException($"Can't set tooltip, '{id}' is not a setting");
-
-            _s.Settings[id].ToolTip = text;
-        }
+    public ASRSettingsBuilder(ASRSettings s)
+    {
+        _s = s;
     }
 
-    /// <summary>
-    /// Interface for reading settings via the ASR Script.
-    /// </summary>
-    public class ASRSettingsReader
+    public void Add(string id, bool default_value = true, string description = null, string parent = null)
     {
-        private ASRSettings _s;
+        if (parent == null)
+            parent = CurrentDefaultParent;
 
-        public ASRSettingsReader(ASRSettings s)
-        {
-            _s = s;
-        }
+        _s.AddSetting(id, default_value, description, parent);
+    }
 
-        public dynamic this[string id]
-        {
-            get { return _s.GetSettingValue(id); }
-        }
+    public void SetToolTip(string id, string text)
+    {
+        if (!_s.Settings.ContainsKey(id))
+            throw new ArgumentException($"Can't set tooltip, '{id}' is not a setting");
 
-        public bool ContainsKey(string key)
-        {
-            return _s.Settings.ContainsKey(key);
-        }
+        _s.Settings[id].ToolTip = text;
+    }
+}
 
-        public bool StartEnabled
-        {
-            get { return _s.GetBasicSettingValue("start"); }
-        }
+/// <summary>
+/// Interface for reading settings via the ASR Script.
+/// </summary>
+public class ASRSettingsReader
+{
+    private ASRSettings _s;
 
-        public bool ResetEnabled
-        {
-            get { return _s.GetBasicSettingValue("reset"); }
-        }
+    public ASRSettingsReader(ASRSettings s)
+    {
+        _s = s;
+    }
 
-        public bool SplitEnabled
-        {
-            get { return _s.GetBasicSettingValue("split"); }
-        }
+    public dynamic this[string id]
+    {
+        get { return _s.GetSettingValue(id); }
+    }
+
+    public bool ContainsKey(string key)
+    {
+        return _s.Settings.ContainsKey(key);
+    }
+
+    public bool StartEnabled
+    {
+        get { return _s.GetBasicSettingValue("start"); }
+    }
+
+    public bool ResetEnabled
+    {
+        get { return _s.GetBasicSettingValue("reset"); }
+    }
+
+    public bool SplitEnabled
+    {
+        get { return _s.GetBasicSettingValue("split"); }
     }
 }

--- a/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
@@ -22,7 +22,7 @@ public partial class ComponentSettings : UserControl
             if (value != scriptPath)
             {
                 scriptPath = value;
-                this.ReloadRuntime(null);
+                ReloadRuntime(null);
             }
         }
     }
@@ -55,7 +55,7 @@ public partial class ComponentSettings : UserControl
 
         scriptPath = "";
 
-        this.txtScriptPath.DataBindings.Add("Text", this, "ScriptPath", false,
+        txtScriptPath.DataBindings.Add("Text", this, "ScriptPath", false,
             DataSourceUpdateMode.OnPropertyChanged);
 
         getState = () =>
@@ -83,10 +83,10 @@ public partial class ComponentSettings : UserControl
     public ComponentSettings(TimerModel model, string scriptPath)
         : this(model)
     {
-        this.ScriptPath = scriptPath;
-        this.fixedScriptPath = true;
-        this.btnSelectFile.Enabled = false;
-        this.txtScriptPath.Enabled = false;
+        ScriptPath = scriptPath;
+        fixedScriptPath = true;
+        btnSelectFile.Enabled = false;
+        txtScriptPath.Enabled = false;
     }
 
     public void ReloadRuntime(SettingsMap settingsMap)
@@ -130,9 +130,9 @@ public partial class ComponentSettings : UserControl
 
     public void BuildTree()
     {
-        this.settingsTable.Controls.Clear();
-        this.settingsTable.RowCount = 0;
-        this.settingsTable.RowStyles.Clear();
+        settingsTable.Controls.Clear();
+        settingsTable.RowCount = 0;
+        settingsTable.RowStyles.Clear();
 
         if (runtime != null)
         {
@@ -165,9 +165,9 @@ public partial class ComponentSettings : UserControl
                         };
                         checkbox.CheckedChanged += Checkbox_CheckedChanged;
                         checkbox.Anchor |= AnchorStyles.Right;
-                        this.toolTip.SetToolTip(checkbox, tooltip);
-                        this.settingsTable.Controls.Add(checkbox, 0, this.settingsTable.RowStyles.Count);
-                        this.settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, checkbox.Height));
+                        toolTip.SetToolTip(checkbox, tooltip);
+                        settingsTable.Controls.Add(checkbox, 0, settingsTable.RowStyles.Count);
+                        settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, checkbox.Height));
                         break;
                     }
                     case "title":
@@ -182,9 +182,9 @@ public partial class ComponentSettings : UserControl
                         margin += 20;
                         label.Font = new Font(label.Font.FontFamily, 10, FontStyle.Underline);
                         label.Anchor |= AnchorStyles.Right;
-                        this.toolTip.SetToolTip(label, tooltip);
-                        this.settingsTable.Controls.Add(label, 0, this.settingsTable.RowStyles.Count);
-                        this.settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, label.Height));
+                        toolTip.SetToolTip(label, tooltip);
+                        settingsTable.Controls.Add(label, 0, settingsTable.RowStyles.Count);
+                        settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, label.Height));
                         break;
                     }
                     case "choice":
@@ -195,9 +195,9 @@ public partial class ComponentSettings : UserControl
                             Margin = new Padding(margin, 0, 0, 0)
                         };
                         label.Anchor |= AnchorStyles.Right;
-                        this.toolTip.SetToolTip(label, tooltip);
-                        this.settingsTable.Controls.Add(label, 0, this.settingsTable.RowStyles.Count);
-                        this.settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, label.Height));
+                        toolTip.SetToolTip(label, tooltip);
+                        settingsTable.Controls.Add(label, 0, settingsTable.RowStyles.Count);
+                        settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, label.Height));
 
                         var combo = new ComboBox
                         {
@@ -206,7 +206,7 @@ public partial class ComponentSettings : UserControl
                             DropDownStyle = ComboBoxStyle.DropDownList
                         };
                         combo.Anchor |= AnchorStyles.Right;
-                        this.toolTip.SetToolTip(combo, tooltip);
+                        toolTip.SetToolTip(combo, tooltip);
                         var choicesLen = widgets.GetChoiceOptionsLength(i);
                         for (ulong choiceIndex = 0; choiceIndex < choicesLen; choiceIndex++)
                         {
@@ -220,8 +220,8 @@ public partial class ComponentSettings : UserControl
 
                         combo.SelectedIndex = (int)widgets.GetChoiceCurrentIndex(i, settingsMap);
                         combo.SelectedIndexChanged += Combo_SelectedIndexChanged;
-                        this.settingsTable.Controls.Add(combo, 0, this.settingsTable.RowStyles.Count);
-                        this.settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, combo.Height + 5));
+                        settingsTable.Controls.Add(combo, 0, settingsTable.RowStyles.Count);
+                        settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, combo.Height + 5));
                         break;
                     }
                     case "file-select":
@@ -234,9 +234,9 @@ public partial class ComponentSettings : UserControl
                         };
                         button.Click += FileSelect_Click;
                         button.Anchor |= AnchorStyles.Right;
-                        this.toolTip.SetToolTip(button, tooltip);
-                        this.settingsTable.Controls.Add(button, 0, this.settingsTable.RowStyles.Count);
-                        this.settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, button.Height));
+                        toolTip.SetToolTip(button, tooltip);
+                        settingsTable.Controls.Add(button, 0, settingsTable.RowStyles.Count);
+                        settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, button.Height));
                         break;
                     }
                     default:
@@ -365,7 +365,7 @@ public partial class ComponentSettings : UserControl
         XmlElement settings_node = document.CreateElement("Settings");
 
         settings_node.AppendChild(SettingsHelper.ToElement(document, "Version", "1.0"));
-        if (!this.fixedScriptPath)
+        if (!fixedScriptPath)
         {
             settings_node.AppendChild(SettingsHelper.ToElement(document, "ScriptPath", scriptPath));
         }
@@ -383,13 +383,13 @@ public partial class ComponentSettings : UserControl
         if (!element.IsEmpty)
         {
             var settingsMap = ParseCustomSettingsFromXml(element);
-            if (!this.fixedScriptPath)
+            if (!fixedScriptPath)
             {
                 var newScriptPath = SettingsHelper.ParseString(element["ScriptPath"], string.Empty);
                 if (newScriptPath != scriptPath)
                 {
                     scriptPath = newScriptPath;
-                    this.ReloadRuntime(settingsMap);
+                    ReloadRuntime(settingsMap);
                     return;
                 }
             }
@@ -646,7 +646,7 @@ public partial class ComponentSettings : UserControl
 
         if (dialog.ShowDialog() == DialogResult.OK)
         {
-            scriptPath = this.txtScriptPath.Text = dialog.FileName;
+            scriptPath = txtScriptPath.Text = dialog.FileName;
         }
     }
 

--- a/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
@@ -251,12 +251,12 @@ public partial class ComponentSettings : UserControl
     private void Combo_SelectedIndexChanged(object sender, EventArgs e)
     {
         var combo = (ComboBox)sender;
-        if (!(combo.Tag is string))
+        if (combo.Tag is not string)
         {
             return;
         }
 
-        if (!(combo.SelectedItem is Choice))
+        if (combo.SelectedItem is not Choice)
         {
             return;
         }
@@ -275,7 +275,7 @@ public partial class ComponentSettings : UserControl
     private void FileSelect_Click(object sender, EventArgs e)
     {
         var button = (Button)sender;
-        if (!(button.Tag is FileSelectInfo))
+        if (button.Tag is not FileSelectInfo)
         {
             return;
         }
@@ -346,7 +346,7 @@ public partial class ComponentSettings : UserControl
     private void Checkbox_CheckedChanged(object sender, EventArgs e)
     {
         var checkbox = (CheckBox)sender;
-        if (!(checkbox.Tag is string))
+        if (checkbox.Tag is not string)
         {
             return;
         }

--- a/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
@@ -35,7 +35,7 @@ public partial class ComponentSettings : UserControl
 
     private static readonly LogDelegate log = (messagePtr, messageLen) =>
     {
-        var message = ASRString.FromPtrLen(messagePtr, messageLen);
+        string message = ASRString.FromPtrLen(messagePtr, messageLen);
         Log.Info($"[Auto Splitting Runtime] {message}");
     };
 
@@ -137,20 +137,20 @@ public partial class ComponentSettings : UserControl
         if (runtime != null)
         {
             previousWidgets?.Dispose();
-            var widgets = previousWidgets = runtime.GetSettingsWidgets();
+            Widgets widgets = previousWidgets = runtime.GetSettingsWidgets();
 
             previousMap?.Dispose();
-            var settingsMap = previousMap = runtime.GetSettingsMap();
+            SettingsMap settingsMap = previousMap = runtime.GetSettingsMap();
 
-            var len = widgets.GetLength();
+            ulong len = widgets.GetLength();
 
-            var margin = 3;
+            int margin = 3;
 
             for (ulong i = 0; i < len; i++)
             {
-                var desc = widgets.GetDescription(i);
-                var tooltip = widgets.GetTooltip(i);
-                var ty = widgets.GetType(i);
+                string desc = widgets.GetDescription(i);
+                string tooltip = widgets.GetTooltip(i);
+                string ty = widgets.GetType(i);
 
                 switch (ty)
                 {
@@ -172,7 +172,7 @@ public partial class ComponentSettings : UserControl
                     }
                     case "title":
                     {
-                        var headingLevel = (int)widgets.GetHeadingLevel(i);
+                        int headingLevel = (int)widgets.GetHeadingLevel(i);
                         margin = 20 * headingLevel;
                         var label = new Label
                         {
@@ -207,7 +207,7 @@ public partial class ComponentSettings : UserControl
                         };
                         combo.Anchor |= AnchorStyles.Right;
                         toolTip.SetToolTip(combo, tooltip);
-                        var choicesLen = widgets.GetChoiceOptionsLength(i);
+                        ulong choicesLen = widgets.GetChoiceOptionsLength(i);
                         for (ulong choiceIndex = 0; choiceIndex < choicesLen; choiceIndex++)
                         {
                             var choice = new Choice
@@ -266,7 +266,7 @@ public partial class ComponentSettings : UserControl
         if (runtime != null)
         {
             runtime.SettingsMapSetString((string)combo.Tag, choice.key);
-            var prev = previousMap;
+            SettingsMap prev = previousMap;
             previousMap = runtime.GetSettingsMap();
             prev?.Dispose();
         }
@@ -280,7 +280,7 @@ public partial class ComponentSettings : UserControl
             return;
         }
 
-        FileSelectInfo tag = (FileSelectInfo)button.Tag;
+        var tag = (FileSelectInfo)button.Tag;
         var dialog = new OpenFileDialog()
         {
             Filter = tag.filter
@@ -312,7 +312,7 @@ public partial class ComponentSettings : UserControl
             if (runtime != null)
             {
                 runtime.SettingsMapSetString(tag.key, newWasiPath);
-                var prev = previousMap;
+                SettingsMap prev = previousMap;
                 previousMap = runtime.GetSettingsMap();
                 prev?.Dispose();
             }
@@ -352,7 +352,7 @@ public partial class ComponentSettings : UserControl
         if (runtime != null)
         {
             runtime.SettingsMapSetBool((string)checkbox.Tag, checkbox.Checked);
-            var prev = previousMap;
+            SettingsMap prev = previousMap;
             previousMap = runtime.GetSettingsMap();
             prev?.Dispose();
         }
@@ -380,10 +380,10 @@ public partial class ComponentSettings : UserControl
         var element = (XmlElement)settings;
         if (!element.IsEmpty)
         {
-            var settingsMap = ParseCustomSettingsFromXml(element);
+            SettingsMap settingsMap = ParseCustomSettingsFromXml(element);
             if (!fixedScriptPath)
             {
-                var newScriptPath = SettingsHelper.ParseString(element["ScriptPath"], string.Empty);
+                string newScriptPath = SettingsHelper.ParseString(element["ScriptPath"], string.Empty);
                 if (newScriptPath != scriptPath)
                 {
                     scriptPath = newScriptPath;
@@ -394,7 +394,7 @@ public partial class ComponentSettings : UserControl
 
             if (runtime != null)
             {
-                var prev = previousMap;
+                SettingsMap prev = previousMap;
                 previousMap = settingsMap ?? new SettingsMap();
                 prev?.Dispose();
                 runtime.SetSettingsMap(previousMap);
@@ -411,7 +411,7 @@ public partial class ComponentSettings : UserControl
 
         if (runtime != null)
         {
-            using var settingsMap = runtime.GetSettingsMap();
+            using SettingsMap settingsMap = runtime.GetSettingsMap();
             if (settingsMap != null)
             {
                 BuildMap(document, asrParent, settingsMap);
@@ -423,7 +423,7 @@ public partial class ComponentSettings : UserControl
 
     private static void BuildMap(XmlDocument document, XmlElement parent, SettingsMapRef settingsMap)
     {
-        var len = settingsMap.GetLength();
+        ulong len = settingsMap.GetLength();
         for (ulong i = 0; i < len; i++)
         {
             XmlElement element = BuildValue(document, settingsMap.GetValue(i));
@@ -439,7 +439,7 @@ public partial class ComponentSettings : UserControl
 
     private static void BuildList(XmlDocument document, XmlElement parent, SettingsListRef settingsList)
     {
-        var len = settingsList.GetLength();
+        ulong len = settingsList.GetLength();
         for (ulong i = 0; i < len; i++)
         {
             XmlElement element = BuildValue(document, settingsList.Get(i));
@@ -455,7 +455,7 @@ public partial class ComponentSettings : UserControl
     {
         XmlElement element = document.CreateElement("Setting");
 
-        var type = value.GetKind();
+        string type = value.GetKind();
 
         XmlAttribute typeAttr = SettingsHelper.ToAttribute(document, "type", type);
         element.Attributes.Append(typeAttr);
@@ -489,7 +489,7 @@ public partial class ComponentSettings : UserControl
             }
             case "string":
             {
-                var attribute = SettingsHelper.ToAttribute(document, "value", value.GetString());
+                XmlAttribute attribute = SettingsHelper.ToAttribute(document, "value", value.GetString());
                 element.Attributes.Append(attribute);
                 break;
             }
@@ -543,7 +543,7 @@ public partial class ComponentSettings : UserControl
                 return null;
             }
 
-            var value = ParseValue(element);
+            SettingValue value = ParseValue(element);
             if (value == null)
             {
                 return null;
@@ -566,7 +566,7 @@ public partial class ComponentSettings : UserControl
                 return null;
             }
 
-            var value = ParseValue(element);
+            SettingValue value = ParseValue(element);
             if (value == null)
             {
                 return null;
@@ -604,7 +604,7 @@ public partial class ComponentSettings : UserControl
         }
         else if (type == "map")
         {
-            var value = ParseMap(element);
+            SettingsMap value = ParseMap(element);
             if (value == null)
             {
                 return null;
@@ -614,7 +614,7 @@ public partial class ComponentSettings : UserControl
         }
         else if (type == "list")
         {
-            var value = ParseList(element);
+            SettingsList value = ParseList(element);
             if (value == null)
             {
                 return null;

--- a/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
@@ -26,7 +26,7 @@ public partial class ComponentSettings : UserControl
             }
         }
     }
-    private bool fixedScriptPath = false;
+    private readonly bool fixedScriptPath = false;
 
     public Runtime runtime = null;
 
@@ -306,7 +306,7 @@ public partial class ComponentSettings : UserControl
         }
     }
 
-    class Choice
+    private class Choice
     {
         public string key;
         public string description;
@@ -317,7 +317,7 @@ public partial class ComponentSettings : UserControl
         }
     }
 
-    struct FileSelectInfo
+    private readonly struct FileSelectInfo
     {
         public FileSelectInfo(string k, string f)
         {

--- a/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
@@ -70,11 +70,11 @@ public partial class ComponentSettings : UserControl
 
             return 0;
         };
-        start = () => model.Start();
-        split = () => model.Split();
-        skipSplit = () => model.SkipSplit();
-        undoSplit = () => model.UndoSplit();
-        reset = () => model.Reset();
+        start = model.Start;
+        split = model.Split;
+        skipSplit = model.SkipSplit;
+        undoSplit = model.UndoSplit;
+        reset = model.Reset;
         setGameTime = (ticks) => model.CurrentState.SetGameTime(new TimeSpan(ticks));
         pauseGameTime = () => model.CurrentState.IsGameTimePaused = true;
         resumeGameTime = () => model.CurrentState.IsGameTimePaused = false;

--- a/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
@@ -1,631 +1,631 @@
 ﻿using System;
 using System.Drawing;
+using System.Globalization;
+using System.IO;
 using System.Windows.Forms;
 using System.Xml;
-using LiveSplit.UI;
-using System.IO;
-using LiveSplit.Options;
+
 using LiveSplit.Model;
-using System.Globalization;
+using LiveSplit.Options;
+using LiveSplit.UI;
 
-namespace LiveSplit.AutoSplittingRuntime
+namespace LiveSplit.AutoSplittingRuntime;
+
+public partial class ComponentSettings : UserControl
 {
-    public partial class ComponentSettings : UserControl
+    private string scriptPath;
+    public string ScriptPath
     {
-        private string scriptPath;
-        public string ScriptPath
+        get => scriptPath;
+        set
         {
-            get => scriptPath;
-            set
+            if (value != scriptPath)
             {
-                if (value != scriptPath)
-                {
-                    scriptPath = value;
-                    this.ReloadRuntime(null);
-                }
+                scriptPath = value;
+                this.ReloadRuntime(null);
             }
         }
-        private bool fixedScriptPath = false;
+    }
+    private bool fixedScriptPath = false;
 
-        public Runtime runtime = null;
+    public Runtime runtime = null;
 
-        public SettingsMap previousMap = null;
-        public Widgets previousWidgets = null;
+    public SettingsMap previousMap = null;
+    public Widgets previousWidgets = null;
 
-        private static readonly LogDelegate log = (messagePtr, messageLen) =>
+    private static readonly LogDelegate log = (messagePtr, messageLen) =>
+    {
+        var message = ASRString.FromPtrLen(messagePtr, messageLen);
+        Log.Info($"[Auto Splitting Runtime] {message}");
+    };
+
+    private readonly StateDelegate getState;
+    private readonly Action start;
+    private readonly Action split;
+    private readonly Action skipSplit;
+    private readonly Action undoSplit;
+    private readonly Action reset;
+    private readonly SetGameTimeDelegate setGameTime;
+    private readonly Action pauseGameTime;
+    private readonly Action resumeGameTime;
+
+    public ComponentSettings(TimerModel model)
+    {
+        InitializeComponent();
+
+        scriptPath = "";
+
+        this.txtScriptPath.DataBindings.Add("Text", this, "ScriptPath", false,
+            DataSourceUpdateMode.OnPropertyChanged);
+
+        getState = () =>
         {
-            var message = ASRString.FromPtrLen(messagePtr, messageLen);
-            Log.Info($"[Auto Splitting Runtime] {message}");
+            switch (model.CurrentState.CurrentPhase)
+            {
+                case TimerPhase.NotRunning: return 0;
+                case TimerPhase.Running: return 1;
+                case TimerPhase.Paused: return 2;
+                case TimerPhase.Ended: return 3;
+            }
+            return 0;
         };
+        start = () => model.Start();
+        split = () => model.Split();
+        skipSplit = () => model.SkipSplit();
+        undoSplit = () => model.UndoSplit();
+        reset = () => model.Reset();
+        setGameTime = (ticks) => model.CurrentState.SetGameTime(new TimeSpan(ticks));
+        pauseGameTime = () => model.CurrentState.IsGameTimePaused = true;
+        resumeGameTime = () => model.CurrentState.IsGameTimePaused = false;
+    }
 
-        private readonly StateDelegate getState;
-        private readonly Action start;
-        private readonly Action split;
-        private readonly Action skipSplit;
-        private readonly Action undoSplit;
-        private readonly Action reset;
-        private readonly SetGameTimeDelegate setGameTime;
-        private readonly Action pauseGameTime;
-        private readonly Action resumeGameTime;
+    public ComponentSettings(TimerModel model, string scriptPath)
+        : this(model)
+    {
+        this.ScriptPath = scriptPath;
+        this.fixedScriptPath = true;
+        this.btnSelectFile.Enabled = false;
+        this.txtScriptPath.Enabled = false;
+    }
 
-        public ComponentSettings(TimerModel model)
+    public void ReloadRuntime(SettingsMap settingsMap)
+    {
+        try
         {
-            InitializeComponent();
-
-            scriptPath = "";
-
-            this.txtScriptPath.DataBindings.Add("Text", this, "ScriptPath", false,
-                DataSourceUpdateMode.OnPropertyChanged);
-
-            getState = () =>
-            {
-                switch (model.CurrentState.CurrentPhase)
-                {
-                    case TimerPhase.NotRunning: return 0;
-                    case TimerPhase.Running: return 1;
-                    case TimerPhase.Paused: return 2;
-                    case TimerPhase.Ended: return 3;
-                }
-                return 0;
-            };
-            start = () => model.Start();
-            split = () => model.Split();
-            skipSplit = () => model.SkipSplit();
-            undoSplit = () => model.UndoSplit();
-            reset = () => model.Reset();
-            setGameTime = (ticks) => model.CurrentState.SetGameTime(new TimeSpan(ticks));
-            pauseGameTime = () => model.CurrentState.IsGameTimePaused = true;
-            resumeGameTime = () => model.CurrentState.IsGameTimePaused = false;
-        }
-
-        public ComponentSettings(TimerModel model, string scriptPath)
-            : this(model)
-        {
-            this.ScriptPath = scriptPath;
-            this.fixedScriptPath = true;
-            this.btnSelectFile.Enabled = false;
-            this.txtScriptPath.Enabled = false;
-        }
-
-        public void ReloadRuntime(SettingsMap settingsMap)
-        {
-            try
-            {
-                if (runtime != null)
-                {
-                    runtime.Dispose();
-                    runtime = null;
-                    previousMap?.Dispose();
-                    previousMap = null;
-                    previousWidgets?.Dispose();
-                    previousWidgets = null;
-                    BuildTree();
-                }
-
-                if (!string.IsNullOrEmpty(ScriptPath))
-                {
-                    runtime = new Runtime(
-                        ScriptPath,
-                        settingsMap,
-                        getState,
-                        start,
-                        split,
-                        skipSplit,
-                        undoSplit,
-                        reset,
-                        setGameTime,
-                        pauseGameTime,
-                        resumeGameTime,
-                        log
-                    );
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex);
-            }
-        }
-
-        public void BuildTree()
-        {
-            this.settingsTable.Controls.Clear();
-            this.settingsTable.RowCount = 0;
-            this.settingsTable.RowStyles.Clear();
-
             if (runtime != null)
             {
-                previousWidgets?.Dispose();
-                var widgets = previousWidgets = runtime.GetSettingsWidgets();
-
+                runtime.Dispose();
+                runtime = null;
                 previousMap?.Dispose();
-                var settingsMap = previousMap = runtime.GetSettingsMap();
+                previousMap = null;
+                previousWidgets?.Dispose();
+                previousWidgets = null;
+                BuildTree();
+            }
 
-                var len = widgets.GetLength();
-
-                var margin = 3;
-
-                for (ulong i = 0; i < len; i++)
-                {
-                    var desc = widgets.GetDescription(i);
-                    var tooltip = widgets.GetTooltip(i);
-                    var ty = widgets.GetType(i);
-
-                    switch (ty)
-                    {
-                        case "bool":
-                            {
-                                var checkbox = new CheckBox
-                                {
-                                    Text = desc,
-                                    Tag = widgets.GetKey(i),
-                                    Margin = new Padding(margin, 0, 0, 0),
-                                    Checked = widgets.GetBool(i, settingsMap)
-                                };
-                                checkbox.CheckedChanged += Checkbox_CheckedChanged;
-                                checkbox.Anchor |= AnchorStyles.Right;
-                                this.toolTip.SetToolTip(checkbox, tooltip);
-                                this.settingsTable.Controls.Add(checkbox, 0, this.settingsTable.RowStyles.Count);
-                                this.settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, checkbox.Height));
-                                break;
-                            }
-                        case "title":
-                            {
-                                var headingLevel = (int)widgets.GetHeadingLevel(i);
-                                margin = 20 * headingLevel;
-                                var label = new Label
-                                {
-                                    Margin = new Padding(margin, 3, 0, 0),
-                                    Text = desc
-                                };
-                                margin += 20;
-                                label.Font = new Font(label.Font.FontFamily, 10, FontStyle.Underline);
-                                label.Anchor |= AnchorStyles.Right;
-                                this.toolTip.SetToolTip(label, tooltip);
-                                this.settingsTable.Controls.Add(label, 0, this.settingsTable.RowStyles.Count);
-                                this.settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, label.Height));
-                                break;
-                            }
-                        case "choice":
-                            {
-                                var label = new Label
-                                {
-                                    Text = desc,
-                                    Margin = new Padding(margin, 0, 0, 0)
-                                };
-                                label.Anchor |= AnchorStyles.Right;
-                                this.toolTip.SetToolTip(label, tooltip);
-                                this.settingsTable.Controls.Add(label, 0, this.settingsTable.RowStyles.Count);
-                                this.settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, label.Height));
-
-                                var combo = new ComboBox
-                                {
-                                    Tag = widgets.GetKey(i),
-                                    Margin = new Padding(margin, 0, 0, 0),
-                                    DropDownStyle = ComboBoxStyle.DropDownList
-                                };
-                                combo.Anchor |= AnchorStyles.Right;
-                                this.toolTip.SetToolTip(combo, tooltip);
-                                var choicesLen = widgets.GetChoiceOptionsLength(i);
-                                for (ulong choiceIndex = 0; choiceIndex < choicesLen; choiceIndex++)
-                                {
-                                    var choice = new Choice
-                                    {
-                                        description = widgets.GetChoiceOptionDescription(i, choiceIndex),
-                                        key = widgets.GetChoiceOptionKey(i, choiceIndex)
-                                    };
-                                    combo.Items.Add(choice);
-                                }
-                                combo.SelectedIndex = (int)widgets.GetChoiceCurrentIndex(i, settingsMap);
-                                combo.SelectedIndexChanged += Combo_SelectedIndexChanged;
-                                this.settingsTable.Controls.Add(combo, 0, this.settingsTable.RowStyles.Count);
-                                this.settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, combo.Height + 5));
-                                break;
-                            }
-                        case "file-select":
-                            {
-                                var button = new Button
-                                {
-                                    Tag = new FileSelectInfo(widgets.GetKey(i), widgets.GetFileSelectFilter(i)),
-                                    Text = desc,
-                                    Margin = new Padding(margin, 0, 0, 0),
-                                };
-                                button.Click += FileSelect_Click;
-                                button.Anchor |= AnchorStyles.Right;
-                                this.toolTip.SetToolTip(button, tooltip);
-                                this.settingsTable.Controls.Add(button, 0, this.settingsTable.RowStyles.Count);
-                                this.settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, button.Height));
-                                break;
-                            }
-                        default:
-                            {
-                                break;
-                            }
-                    }
-                }
+            if (!string.IsNullOrEmpty(ScriptPath))
+            {
+                runtime = new Runtime(
+                    ScriptPath,
+                    settingsMap,
+                    getState,
+                    start,
+                    split,
+                    skipSplit,
+                    undoSplit,
+                    reset,
+                    setGameTime,
+                    pauseGameTime,
+                    resumeGameTime,
+                    log
+                );
             }
         }
-
-        private void Combo_SelectedIndexChanged(object sender, EventArgs e)
+        catch (Exception ex)
         {
-            var combo = (ComboBox)sender;
-            if (!(combo.Tag is string)) return;
-            if (!(combo.SelectedItem is Choice)) return;
-            var choice = (Choice)combo.SelectedItem;
-
-            if (runtime != null)
-            {
-                runtime.SettingsMapSetString((string)combo.Tag, choice.key);
-                var prev = previousMap;
-                previousMap = runtime.GetSettingsMap();
-                prev?.Dispose();
-            }
+            Log.Error(ex);
         }
+    }
 
-        private void FileSelect_Click(object sender, EventArgs e)
+    public void BuildTree()
+    {
+        this.settingsTable.Controls.Clear();
+        this.settingsTable.RowCount = 0;
+        this.settingsTable.RowStyles.Clear();
+
+        if (runtime != null)
         {
-            var button = (Button)sender;
-            if (!(button.Tag is FileSelectInfo)) return;
-            FileSelectInfo tag = (FileSelectInfo)button.Tag;
-            var dialog = new OpenFileDialog()
+            previousWidgets?.Dispose();
+            var widgets = previousWidgets = runtime.GetSettingsWidgets();
+
+            previousMap?.Dispose();
+            var settingsMap = previousMap = runtime.GetSettingsMap();
+
+            var len = widgets.GetLength();
+
+            var margin = 3;
+
+            for (ulong i = 0; i < len; i++)
             {
-                Filter = tag.filter
-            };
-            string oldWindowsPath = "";
-            if (runtime != null)
-            {
-                using (SettingsMap settingsMap = runtime.GetSettingsMap())
+                var desc = widgets.GetDescription(i);
+                var tooltip = widgets.GetTooltip(i);
+                var ty = widgets.GetType(i);
+
+                switch (ty)
                 {
-                    if (settingsMap != null)
+                    case "bool":
                     {
-                        SettingValueRef value = settingsMap.KeyGetValue(tag.key);
-                        if (value != null)
+                        var checkbox = new CheckBox
                         {
-                            oldWindowsPath = ASRNative.wasi_to_path(value.GetString());
+                            Text = desc,
+                            Tag = widgets.GetKey(i),
+                            Margin = new Padding(margin, 0, 0, 0),
+                            Checked = widgets.GetBool(i, settingsMap)
+                        };
+                        checkbox.CheckedChanged += Checkbox_CheckedChanged;
+                        checkbox.Anchor |= AnchorStyles.Right;
+                        this.toolTip.SetToolTip(checkbox, tooltip);
+                        this.settingsTable.Controls.Add(checkbox, 0, this.settingsTable.RowStyles.Count);
+                        this.settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, checkbox.Height));
+                        break;
+                    }
+                    case "title":
+                    {
+                        var headingLevel = (int)widgets.GetHeadingLevel(i);
+                        margin = 20 * headingLevel;
+                        var label = new Label
+                        {
+                            Margin = new Padding(margin, 3, 0, 0),
+                            Text = desc
+                        };
+                        margin += 20;
+                        label.Font = new Font(label.Font.FontFamily, 10, FontStyle.Underline);
+                        label.Anchor |= AnchorStyles.Right;
+                        this.toolTip.SetToolTip(label, tooltip);
+                        this.settingsTable.Controls.Add(label, 0, this.settingsTable.RowStyles.Count);
+                        this.settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, label.Height));
+                        break;
+                    }
+                    case "choice":
+                    {
+                        var label = new Label
+                        {
+                            Text = desc,
+                            Margin = new Padding(margin, 0, 0, 0)
+                        };
+                        label.Anchor |= AnchorStyles.Right;
+                        this.toolTip.SetToolTip(label, tooltip);
+                        this.settingsTable.Controls.Add(label, 0, this.settingsTable.RowStyles.Count);
+                        this.settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, label.Height));
+
+                        var combo = new ComboBox
+                        {
+                            Tag = widgets.GetKey(i),
+                            Margin = new Padding(margin, 0, 0, 0),
+                            DropDownStyle = ComboBoxStyle.DropDownList
+                        };
+                        combo.Anchor |= AnchorStyles.Right;
+                        this.toolTip.SetToolTip(combo, tooltip);
+                        var choicesLen = widgets.GetChoiceOptionsLength(i);
+                        for (ulong choiceIndex = 0; choiceIndex < choicesLen; choiceIndex++)
+                        {
+                            var choice = new Choice
+                            {
+                                description = widgets.GetChoiceOptionDescription(i, choiceIndex),
+                                key = widgets.GetChoiceOptionKey(i, choiceIndex)
+                            };
+                            combo.Items.Add(choice);
                         }
+                        combo.SelectedIndex = (int)widgets.GetChoiceCurrentIndex(i, settingsMap);
+                        combo.SelectedIndexChanged += Combo_SelectedIndexChanged;
+                        this.settingsTable.Controls.Add(combo, 0, this.settingsTable.RowStyles.Count);
+                        this.settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, combo.Height + 5));
+                        break;
+                    }
+                    case "file-select":
+                    {
+                        var button = new Button
+                        {
+                            Tag = new FileSelectInfo(widgets.GetKey(i), widgets.GetFileSelectFilter(i)),
+                            Text = desc,
+                            Margin = new Padding(margin, 0, 0, 0),
+                        };
+                        button.Click += FileSelect_Click;
+                        button.Anchor |= AnchorStyles.Right;
+                        this.toolTip.SetToolTip(button, tooltip);
+                        this.settingsTable.Controls.Add(button, 0, this.settingsTable.RowStyles.Count);
+                        this.settingsTable.RowStyles.Add(new RowStyle(SizeType.Absolute, button.Height));
+                        break;
+                    }
+                    default:
+                    {
+                        break;
                     }
                 }
             }
-            if (File.Exists(oldWindowsPath))
-            {
-                dialog.InitialDirectory = Path.GetDirectoryName(oldWindowsPath);
-                dialog.FileName = Path.GetFileName(oldWindowsPath);
-            }
+        }
+    }
 
-            if (dialog.ShowDialog() == DialogResult.OK)
+    private void Combo_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        var combo = (ComboBox)sender;
+        if (!(combo.Tag is string)) return;
+        if (!(combo.SelectedItem is Choice)) return;
+        var choice = (Choice)combo.SelectedItem;
+
+        if (runtime != null)
+        {
+            runtime.SettingsMapSetString((string)combo.Tag, choice.key);
+            var prev = previousMap;
+            previousMap = runtime.GetSettingsMap();
+            prev?.Dispose();
+        }
+    }
+
+    private void FileSelect_Click(object sender, EventArgs e)
+    {
+        var button = (Button)sender;
+        if (!(button.Tag is FileSelectInfo)) return;
+        FileSelectInfo tag = (FileSelectInfo)button.Tag;
+        var dialog = new OpenFileDialog()
+        {
+            Filter = tag.filter
+        };
+        string oldWindowsPath = "";
+        if (runtime != null)
+        {
+            using (SettingsMap settingsMap = runtime.GetSettingsMap())
             {
-                string newWindowsPath = dialog.FileName;
-                string newWasiPath = ASRNative.path_to_wasi(newWindowsPath);
-                if (runtime != null)
+                if (settingsMap != null)
                 {
-                    runtime.SettingsMapSetString(tag.key, newWasiPath);
-                    var prev = previousMap;
-                    previousMap = runtime.GetSettingsMap();
-                    prev?.Dispose();
+                    SettingValueRef value = settingsMap.KeyGetValue(tag.key);
+                    if (value != null)
+                    {
+                        oldWindowsPath = ASRNative.wasi_to_path(value.GetString());
+                    }
                 }
             }
         }
-
-        class Choice
+        if (File.Exists(oldWindowsPath))
         {
-            public string key;
-            public string description;
-
-            public override string ToString()
-            {
-                return description;
-            }
+            dialog.InitialDirectory = Path.GetDirectoryName(oldWindowsPath);
+            dialog.FileName = Path.GetFileName(oldWindowsPath);
         }
 
-        struct FileSelectInfo
+        if (dialog.ShowDialog() == DialogResult.OK)
         {
-            public FileSelectInfo(string k, string f)
-            {
-                key = k;
-                filter = f;
-            }
-            public readonly string key;
-            public readonly string filter;
-        }
-
-        private void Checkbox_CheckedChanged(object sender, EventArgs e)
-        {
-            var checkbox = (CheckBox)sender;
-            if (!(checkbox.Tag is string)) return;
-
+            string newWindowsPath = dialog.FileName;
+            string newWasiPath = ASRNative.path_to_wasi(newWindowsPath);
             if (runtime != null)
             {
-                runtime.SettingsMapSetBool((string)checkbox.Tag, checkbox.Checked);
+                runtime.SettingsMapSetString(tag.key, newWasiPath);
                 var prev = previousMap;
                 previousMap = runtime.GetSettingsMap();
                 prev?.Dispose();
             }
+        }
+    }
 
+    class Choice
+    {
+        public string key;
+        public string description;
+
+        public override string ToString()
+        {
+            return description;
+        }
+    }
+
+    struct FileSelectInfo
+    {
+        public FileSelectInfo(string k, string f)
+        {
+            key = k;
+            filter = f;
+        }
+        public readonly string key;
+        public readonly string filter;
+    }
+
+    private void Checkbox_CheckedChanged(object sender, EventArgs e)
+    {
+        var checkbox = (CheckBox)sender;
+        if (!(checkbox.Tag is string)) return;
+
+        if (runtime != null)
+        {
+            runtime.SettingsMapSetBool((string)checkbox.Tag, checkbox.Checked);
+            var prev = previousMap;
+            previousMap = runtime.GetSettingsMap();
+            prev?.Dispose();
         }
 
-        public XmlNode GetSettings(XmlDocument document)
-        {
-            XmlElement settings_node = document.CreateElement("Settings");
+    }
 
-            settings_node.AppendChild(SettingsHelper.ToElement(document, "Version", "1.0"));
+    public XmlNode GetSettings(XmlDocument document)
+    {
+        XmlElement settings_node = document.CreateElement("Settings");
+
+        settings_node.AppendChild(SettingsHelper.ToElement(document, "Version", "1.0"));
+        if (!this.fixedScriptPath)
+        {
+            settings_node.AppendChild(SettingsHelper.ToElement(document, "ScriptPath", scriptPath));
+        }
+        AppendCustomSettingsToXml(document, settings_node);
+
+        return settings_node;
+    }
+
+    // Loads the settings of this component from Xml. This might happen more than once
+    // (e.g. when the settings dialog is cancelled, to restore previous settings).
+    public void SetSettings(XmlNode settings)
+    {
+        var element = (XmlElement)settings;
+        if (!element.IsEmpty)
+        {
+            var settingsMap = ParseCustomSettingsFromXml(element);
             if (!this.fixedScriptPath)
             {
-                settings_node.AppendChild(SettingsHelper.ToElement(document, "ScriptPath", scriptPath));
-            }
-            AppendCustomSettingsToXml(document, settings_node);
-
-            return settings_node;
-        }
-
-        // Loads the settings of this component from Xml. This might happen more than once
-        // (e.g. when the settings dialog is cancelled, to restore previous settings).
-        public void SetSettings(XmlNode settings)
-        {
-            var element = (XmlElement)settings;
-            if (!element.IsEmpty)
-            {
-                var settingsMap = ParseCustomSettingsFromXml(element);
-                if (!this.fixedScriptPath)
+                var newScriptPath = SettingsHelper.ParseString(element["ScriptPath"], string.Empty);
+                if (newScriptPath != scriptPath)
                 {
-                    var newScriptPath = SettingsHelper.ParseString(element["ScriptPath"], string.Empty);
-                    if (newScriptPath != scriptPath)
-                    {
-                        scriptPath = newScriptPath;
-                        this.ReloadRuntime(settingsMap);
-                        return;
-                    }
-                }
-                if (runtime != null)
-                {
-                    var prev = previousMap;
-                    previousMap = settingsMap ?? new SettingsMap();
-                    prev?.Dispose();
-                    runtime.SetSettingsMap(previousMap);
+                    scriptPath = newScriptPath;
+                    this.ReloadRuntime(settingsMap);
                     return;
                 }
-                settingsMap?.Dispose();
             }
-        }
-
-        private void AppendCustomSettingsToXml(XmlDocument document, XmlNode parent)
-        {
-            XmlElement asrParent = document.CreateElement("CustomSettings");
-
             if (runtime != null)
             {
-                using (var settingsMap = runtime.GetSettingsMap())
-                {
-                    if (settingsMap != null)
-                    {
-                        BuildMap(document, asrParent, settingsMap);
-                    }
-                }
+                var prev = previousMap;
+                previousMap = settingsMap ?? new SettingsMap();
+                prev?.Dispose();
+                runtime.SetSettingsMap(previousMap);
+                return;
             }
-
-            parent.AppendChild(asrParent);
+            settingsMap?.Dispose();
         }
+    }
 
-        private static void BuildMap(XmlDocument document, XmlElement parent, SettingsMapRef settingsMap)
+    private void AppendCustomSettingsToXml(XmlDocument document, XmlNode parent)
+    {
+        XmlElement asrParent = document.CreateElement("CustomSettings");
+
+        if (runtime != null)
         {
-            var len = settingsMap.GetLength();
-            for (ulong i = 0; i < len; i++)
+            using (var settingsMap = runtime.GetSettingsMap())
             {
-                XmlElement element = BuildValue(document, settingsMap.GetValue(i));
-
-                if (element != null)
+                if (settingsMap != null)
                 {
-                    XmlAttribute id = SettingsHelper.ToAttribute(document, "id", settingsMap.GetKey(i));
-                    element.Attributes.Prepend(id);
-                    parent.AppendChild(element);
+                    BuildMap(document, asrParent, settingsMap);
                 }
             }
         }
 
-        private static void BuildList(XmlDocument document, XmlElement parent, SettingsListRef settingsList)
-        {
-            var len = settingsList.GetLength();
-            for (ulong i = 0; i < len; i++)
-            {
-                XmlElement element = BuildValue(document, settingsList.Get(i));
+        parent.AppendChild(asrParent);
+    }
 
-                if (element != null)
-                {
-                    parent.AppendChild(element);
-                }
+    private static void BuildMap(XmlDocument document, XmlElement parent, SettingsMapRef settingsMap)
+    {
+        var len = settingsMap.GetLength();
+        for (ulong i = 0; i < len; i++)
+        {
+            XmlElement element = BuildValue(document, settingsMap.GetValue(i));
+
+            if (element != null)
+            {
+                XmlAttribute id = SettingsHelper.ToAttribute(document, "id", settingsMap.GetKey(i));
+                element.Attributes.Prepend(id);
+                parent.AppendChild(element);
             }
         }
+    }
 
-        private static XmlElement BuildValue(XmlDocument document, SettingValueRef value)
+    private static void BuildList(XmlDocument document, XmlElement parent, SettingsListRef settingsList)
+    {
+        var len = settingsList.GetLength();
+        for (ulong i = 0; i < len; i++)
         {
-            XmlElement element = document.CreateElement("Setting");
+            XmlElement element = BuildValue(document, settingsList.Get(i));
 
-            var type = value.GetKind();
-
-            XmlAttribute typeAttr = SettingsHelper.ToAttribute(document, "type", type);
-            element.Attributes.Append(typeAttr);
-
-            switch (type)
+            if (element != null)
             {
-                case "map":
-                    {
-                        BuildMap(document, element, value.GetMap());
-                        break;
-                    }
-                case "list":
-                    {
-                        BuildList(document, element, value.GetList());
-                        break;
-                    }
-                case "bool":
-                    {
-                        element.InnerText = value.GetBool().ToString(CultureInfo.InvariantCulture);
-                        break;
-                    }
-                case "i64":
-                    {
-                        element.InnerText = value.GetI64().ToString(CultureInfo.InvariantCulture);
-                        break;
-                    }
-                case "f64":
-                    {
-                        element.InnerText = value.GetF64().ToString(CultureInfo.InvariantCulture);
-                        break;
-                    }
-                case "string":
-                    {
-                        var attribute = SettingsHelper.ToAttribute(document, "value", value.GetString());
-                        element.Attributes.Append(attribute);
-                        break;
-                    }
-                default:
-                    {
-                        return null;
-                    }
+                parent.AppendChild(element);
             }
-
-
-            return element;
         }
+    }
 
-        /// <summary>
-        /// Parses custom settings, stores them and updates the checked state of already added tree nodes.
-        /// </summary>
-        ///
-        private SettingsMap ParseCustomSettingsFromXml(XmlElement data)
+    private static XmlElement BuildValue(XmlDocument document, SettingValueRef value)
+    {
+        XmlElement element = document.CreateElement("Setting");
+
+        var type = value.GetKind();
+
+        XmlAttribute typeAttr = SettingsHelper.ToAttribute(document, "type", type);
+        element.Attributes.Append(typeAttr);
+
+        switch (type)
         {
-            try
+            case "map":
             {
-                XmlElement customSettingsNode = data["CustomSettings"];
-
-                if (customSettingsNode == null)
-                {
-                    return null;
-                }
-
-                return ParseMap(customSettingsNode);
+                BuildMap(document, element, value.GetMap());
+                break;
             }
-            catch
+            case "list":
+            {
+                BuildList(document, element, value.GetList());
+                break;
+            }
+            case "bool":
+            {
+                element.InnerText = value.GetBool().ToString(CultureInfo.InvariantCulture);
+                break;
+            }
+            case "i64":
+            {
+                element.InnerText = value.GetI64().ToString(CultureInfo.InvariantCulture);
+                break;
+            }
+            case "f64":
+            {
+                element.InnerText = value.GetF64().ToString(CultureInfo.InvariantCulture);
+                break;
+            }
+            case "string":
+            {
+                var attribute = SettingsHelper.ToAttribute(document, "value", value.GetString());
+                element.Attributes.Append(attribute);
+                break;
+            }
+            default:
             {
                 return null;
             }
         }
 
-        private SettingsMap ParseMap(XmlElement mapNode)
+
+        return element;
+    }
+
+    /// <summary>
+    /// Parses custom settings, stores them and updates the checked state of already added tree nodes.
+    /// </summary>
+    ///
+    private SettingsMap ParseCustomSettingsFromXml(XmlElement data)
+    {
+        try
         {
-            var map = new SettingsMap();
+            XmlElement customSettingsNode = data["CustomSettings"];
 
-            foreach (XmlElement element in mapNode.ChildNodes)
-            {
-                if (element.Name != "Setting")
-                    return null;
-
-                string id = element.Attributes["id"].Value;
-
-                if (id == null)
-                {
-                    return null;
-                }
-
-                var value = ParseValue(element);
-                if (value == null)
-                {
-                    return null;
-                }
-
-                map.Insert(id, value);
-            }
-
-            return map;
-        }
-
-        private SettingsList ParseList(XmlElement listNode)
-        {
-            var list = new SettingsList();
-
-            foreach (XmlElement element in listNode.ChildNodes)
-            {
-                if (element.Name != "Setting")
-                    return null;
-
-                var value = ParseValue(element);
-                if (value == null)
-                {
-                    return null;
-                }
-
-                list.Push(value);
-            }
-
-            return list;
-        }
-
-        private SettingValue ParseValue(XmlElement element)
-        {
-            string type = element.Attributes["type"].Value;
-
-            if (type == "bool")
-            {
-                bool value = SettingsHelper.ParseBool(element);
-                return new SettingValue(value);
-            }
-            else if (type == "i64")
-            {
-                long value = long.Parse(element.InnerText);
-                return new SettingValue(value);
-            }
-            else if (type == "f64")
-            {
-                double value = SettingsHelper.ParseDouble(element);
-                return new SettingValue(value);
-            }
-            else if (type == "string")
-            {
-                string value = element.Attributes["value"].Value;
-                return new SettingValue(value);
-            }
-            else if (type == "map")
-            {
-                var value = ParseMap(element);
-                if (value == null)
-                {
-                    return null;
-                }
-                return new SettingValue(value);
-            }
-            else if (type == "list")
-            {
-                var value = ParseList(element);
-                if (value == null)
-                {
-                    return null;
-                }
-                return new SettingValue(value);
-            }
-            else
+            if (customSettingsNode == null)
             {
                 return null;
             }
-        }
 
-        private void btnSelectFile_Click(object sender, EventArgs e)
+            return ParseMap(customSettingsNode);
+        }
+        catch
         {
-            var dialog = new OpenFileDialog()
+            return null;
+        }
+    }
+
+    private SettingsMap ParseMap(XmlElement mapNode)
+    {
+        var map = new SettingsMap();
+
+        foreach (XmlElement element in mapNode.ChildNodes)
+        {
+            if (element.Name != "Setting")
+                return null;
+
+            string id = element.Attributes["id"].Value;
+
+            if (id == null)
             {
-                Filter = "WebAssembly module (*.wasm)|*.wasm|All Files (*.*)|*.*"
-            };
-            if (File.Exists(ScriptPath))
-            {
-                dialog.InitialDirectory = Path.GetDirectoryName(ScriptPath);
-                dialog.FileName = Path.GetFileName(ScriptPath);
+                return null;
             }
 
-            if (dialog.ShowDialog() == DialogResult.OK)
+            var value = ParseValue(element);
+            if (value == null)
             {
-                scriptPath = this.txtScriptPath.Text = dialog.FileName;
+                return null;
             }
+
+            map.Insert(id, value);
         }
 
-        private void ComponentSettings_Load(object sender, EventArgs e)
+        return map;
+    }
+
+    private SettingsList ParseList(XmlElement listNode)
+    {
+        var list = new SettingsList();
+
+        foreach (XmlElement element in listNode.ChildNodes)
         {
+            if (element.Name != "Setting")
+                return null;
+
+            var value = ParseValue(element);
+            if (value == null)
+            {
+                return null;
+            }
+
+            list.Push(value);
         }
+
+        return list;
+    }
+
+    private SettingValue ParseValue(XmlElement element)
+    {
+        string type = element.Attributes["type"].Value;
+
+        if (type == "bool")
+        {
+            bool value = SettingsHelper.ParseBool(element);
+            return new SettingValue(value);
+        }
+        else if (type == "i64")
+        {
+            long value = long.Parse(element.InnerText);
+            return new SettingValue(value);
+        }
+        else if (type == "f64")
+        {
+            double value = SettingsHelper.ParseDouble(element);
+            return new SettingValue(value);
+        }
+        else if (type == "string")
+        {
+            string value = element.Attributes["value"].Value;
+            return new SettingValue(value);
+        }
+        else if (type == "map")
+        {
+            var value = ParseMap(element);
+            if (value == null)
+            {
+                return null;
+            }
+            return new SettingValue(value);
+        }
+        else if (type == "list")
+        {
+            var value = ParseList(element);
+            if (value == null)
+            {
+                return null;
+            }
+            return new SettingValue(value);
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    private void btnSelectFile_Click(object sender, EventArgs e)
+    {
+        var dialog = new OpenFileDialog()
+        {
+            Filter = "WebAssembly module (*.wasm)|*.wasm|All Files (*.*)|*.*"
+        };
+        if (File.Exists(ScriptPath))
+        {
+            dialog.InitialDirectory = Path.GetDirectoryName(ScriptPath);
+            dialog.FileName = Path.GetFileName(ScriptPath);
+        }
+
+        if (dialog.ShowDialog() == DialogResult.OK)
+        {
+            scriptPath = this.txtScriptPath.Text = dialog.FileName;
+        }
+    }
+
+    private void ComponentSettings_Load(object sender, EventArgs e)
+    {
     }
 }

--- a/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
@@ -67,6 +67,7 @@ public partial class ComponentSettings : UserControl
                 case TimerPhase.Paused: return 2;
                 case TimerPhase.Ended: return 3;
             }
+
             return 0;
         };
         start = () => model.Start();
@@ -216,6 +217,7 @@ public partial class ComponentSettings : UserControl
                             };
                             combo.Items.Add(choice);
                         }
+
                         combo.SelectedIndex = (int)widgets.GetChoiceCurrentIndex(i, settingsMap);
                         combo.SelectedIndexChanged += Combo_SelectedIndexChanged;
                         this.settingsTable.Controls.Add(combo, 0, this.settingsTable.RowStyles.Count);
@@ -249,8 +251,16 @@ public partial class ComponentSettings : UserControl
     private void Combo_SelectedIndexChanged(object sender, EventArgs e)
     {
         var combo = (ComboBox)sender;
-        if (!(combo.Tag is string)) return;
-        if (!(combo.SelectedItem is Choice)) return;
+        if (!(combo.Tag is string))
+        {
+            return;
+        }
+
+        if (!(combo.SelectedItem is Choice))
+        {
+            return;
+        }
+
         var choice = (Choice)combo.SelectedItem;
 
         if (runtime != null)
@@ -265,7 +275,11 @@ public partial class ComponentSettings : UserControl
     private void FileSelect_Click(object sender, EventArgs e)
     {
         var button = (Button)sender;
-        if (!(button.Tag is FileSelectInfo)) return;
+        if (!(button.Tag is FileSelectInfo))
+        {
+            return;
+        }
+
         FileSelectInfo tag = (FileSelectInfo)button.Tag;
         var dialog = new OpenFileDialog()
         {
@@ -286,6 +300,7 @@ public partial class ComponentSettings : UserControl
                 }
             }
         }
+
         if (File.Exists(oldWindowsPath))
         {
             dialog.InitialDirectory = Path.GetDirectoryName(oldWindowsPath);
@@ -331,7 +346,10 @@ public partial class ComponentSettings : UserControl
     private void Checkbox_CheckedChanged(object sender, EventArgs e)
     {
         var checkbox = (CheckBox)sender;
-        if (!(checkbox.Tag is string)) return;
+        if (!(checkbox.Tag is string))
+        {
+            return;
+        }
 
         if (runtime != null)
         {
@@ -340,7 +358,6 @@ public partial class ComponentSettings : UserControl
             previousMap = runtime.GetSettingsMap();
             prev?.Dispose();
         }
-
     }
 
     public XmlNode GetSettings(XmlDocument document)
@@ -352,6 +369,7 @@ public partial class ComponentSettings : UserControl
         {
             settings_node.AppendChild(SettingsHelper.ToElement(document, "ScriptPath", scriptPath));
         }
+
         AppendCustomSettingsToXml(document, settings_node);
 
         return settings_node;
@@ -375,6 +393,7 @@ public partial class ComponentSettings : UserControl
                     return;
                 }
             }
+
             if (runtime != null)
             {
                 var prev = previousMap;
@@ -383,6 +402,7 @@ public partial class ComponentSettings : UserControl
                 runtime.SetSettingsMap(previousMap);
                 return;
             }
+
             settingsMap?.Dispose();
         }
     }
@@ -483,7 +503,6 @@ public partial class ComponentSettings : UserControl
             }
         }
 
-
         return element;
     }
 
@@ -517,7 +536,9 @@ public partial class ComponentSettings : UserControl
         foreach (XmlElement element in mapNode.ChildNodes)
         {
             if (element.Name != "Setting")
+            {
                 return null;
+            }
 
             string id = element.Attributes["id"].Value;
 
@@ -545,7 +566,9 @@ public partial class ComponentSettings : UserControl
         foreach (XmlElement element in listNode.ChildNodes)
         {
             if (element.Name != "Setting")
+            {
                 return null;
+            }
 
             var value = ParseValue(element);
             if (value == null)
@@ -590,6 +613,7 @@ public partial class ComponentSettings : UserControl
             {
                 return null;
             }
+
             return new SettingValue(value);
         }
         else if (type == "list")
@@ -599,6 +623,7 @@ public partial class ComponentSettings : UserControl
             {
                 return null;
             }
+
             return new SettingValue(value);
         }
         else

--- a/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
@@ -288,15 +288,13 @@ public partial class ComponentSettings : UserControl
         string oldWindowsPath = "";
         if (runtime != null)
         {
-            using (SettingsMap settingsMap = runtime.GetSettingsMap())
+            using SettingsMap settingsMap = runtime.GetSettingsMap();
+            if (settingsMap != null)
             {
-                if (settingsMap != null)
+                SettingValueRef value = settingsMap.KeyGetValue(tag.key);
+                if (value != null)
                 {
-                    SettingValueRef value = settingsMap.KeyGetValue(tag.key);
-                    if (value != null)
-                    {
-                        oldWindowsPath = ASRNative.wasi_to_path(value.GetString());
-                    }
+                    oldWindowsPath = ASRNative.wasi_to_path(value.GetString());
                 }
             }
         }
@@ -413,12 +411,10 @@ public partial class ComponentSettings : UserControl
 
         if (runtime != null)
         {
-            using (var settingsMap = runtime.GetSettingsMap())
+            using var settingsMap = runtime.GetSettingsMap();
+            if (settingsMap != null)
             {
-                if (settingsMap != null)
-                {
-                    BuildMap(document, asrParent, settingsMap);
-                }
+                BuildMap(document, asrParent, settingsMap);
             }
         }
 

--- a/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
@@ -60,15 +60,14 @@ public partial class ComponentSettings : UserControl
 
         getState = () =>
         {
-            switch (model.CurrentState.CurrentPhase)
+            return model.CurrentState.CurrentPhase switch
             {
-                case TimerPhase.NotRunning: return 0;
-                case TimerPhase.Running: return 1;
-                case TimerPhase.Paused: return 2;
-                case TimerPhase.Ended: return 3;
-            }
-
-            return 0;
+                TimerPhase.NotRunning => 0,
+                TimerPhase.Running => 1,
+                TimerPhase.Paused => 2,
+                TimerPhase.Ended => 3,
+                _ => 0,
+            };
         };
         start = model.Start;
         split = model.Split;

--- a/src/LiveSplit.AutoSplittingRuntime/LiveSplit.AutoSplittingRuntime.csproj
+++ b/src/LiveSplit.AutoSplittingRuntime/LiveSplit.AutoSplittingRuntime.csproj
@@ -19,6 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 


### PR DESCRIPTION
Parent PR: https://github.com/LiveSplit/LiveSplit/pull/2533

### Description

* Introduces an `.editorconfig` file to enforce consistent style rules.
* Upgrades the language version to C# 12 (most recent stable).
* Adds `PolySharp` to allow for support of some language features which require runtime support (`Index` & `Range` operators).
* Fixes some warnings.
