### PR TITLE
Improve display of wasm settings titles

### DIFF
--- a/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ComponentSettings.cs
@@ -184,10 +184,9 @@ public partial class ComponentSettings : UserControl
                         var label = new Label
                         {
                             Margin = new Padding(margin, 3, 0, 0),
-                            Text = desc
+                            Text = $"—  {desc}"
                         };
                         margin += 20;
-                        label.Font = new Font(label.Font.FontFamily, 10, FontStyle.Underline);
                         label.Anchor |= AnchorStyles.Right;
                         toolTip.SetToolTip(label, tooltip);
                         settingsTable.Controls.Add(label, 0, settingsTable.RowStyles.Count);


### PR DESCRIPTION
Current display of the settings for wasm components works as the following image:

![before](https://github.com/user-attachments/assets/59a8d4da-0bda-4b58-9597-13fcce264280)

This is already acceptable, but can be slightly improved because:
- The increased text size is inconsistent with the rest of livesplit's gui
- The underlined text can mislead into thinking those might be links

This PR fixes display of settings titles:

![image](https://github.com/user-attachments/assets/cc05727f-11d3-4440-8cb2-250399d1e7a1)

