### PR TITLE
Init parentForm in 2-arg ASRComponent constructor

### DIFF
--- a/src/LiveSplit.AutoSplittingRuntime/ASRComponent.cs
+++ b/src/LiveSplit.AutoSplittingRuntime/ASRComponent.cs
@@ -39,6 +39,8 @@ public class ASRComponent : LogicComponent
 
     public ASRComponent(LiveSplitState state, string scriptPath)
     {
+        parentForm = state.Form;
+
         model = new TimerModel() { CurrentState = state };
 
         settings = new ComponentSettings(model, scriptPath);


### PR DESCRIPTION
This fixes an issue with the the autosplitter Settings from Edit Splits for an autosplitter from LiveSplit.AutoSplitters.xml rather than from the Layout.